### PR TITLE
Turn back on precompilation

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -21,6 +21,8 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+__precompile__()
+
 module FixedPointDecimals
 
 export FixedDecimal


### PR DESCRIPTION
Precompilation was inherited from Currencies originally, but was lost in the transfer. This restores it.