### PR TITLE
Better support for dividing by integers

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -34,6 +34,8 @@ import Base: reinterpret, zero, one, abs, sign, ==, <, <=, +, -, /, *, div,
              typemin, typemax, realmin, realmax, print, show, string, convert,
              promote_rule, min, max, trunc, round, floor, ceil, eps, float, widemul
 
+import Base.Checked: checked_mul
+
 const IEEEFloat = Union{Float16, Float32, Float64}
 
 for fn in [:trunc, :floor, :ceil]
@@ -146,7 +148,7 @@ end
 # these functions are needed to avoid InexactError when converting from the integer type
 function /{T, f}(x::Integer, y::FD{T, f})
     powt = T(10)^f
-    xi = widemul(x, powt)
+    xi = checked_mul(x, powt)
     yi = y.i
     quotient, remainder = divrem(xi, yi)
     reinterpret(FD{T, f}, quotient * powt + round(T, remainder / yi * powt))
@@ -155,7 +157,7 @@ end
 function /{T, f}(x::FD{T, f}, y::Integer)
     powt = T(10)^f
     xi = x.i
-    yi = widemul(y, powt)
+    yi = checked_mul(y, powt)
     quotient, remainder = divrem(xi, yi)
     reinterpret(FD{T, f}, quotient * powt + round(T, remainder / yi * powt))
 end

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -143,6 +143,10 @@ function /{T, f}(x::FD{T, f}, y::FD{T, f})
     reinterpret(FD{T, f}, quotient * powt + round(T, remainder / y.i * powt))
 end
 
+# these functions are needed to avoid InexactError when converting from the integer type
+/{T, f}(x::Integer, y::FD{T, f}) = reinterpret(FD{T, f}, round(T, x / y.i))
+/{T, f}(x::FD{T, f}, y::Integer) = reinterpret(FD{T, f}, round(T, x.i / y))
+
 # integerification
 trunc{T, f}(x::FD{T, f}) = FD{T, f}(div(x.i, T(10)^f))
 floor{T, f}(x::FD{T, f}) = FD{T, f}(fld(x.i, T(10)^f))

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -148,16 +148,14 @@ end
 # these functions are needed to avoid InexactError when converting from the integer type
 function /{T, f}(x::Integer, y::FD{T, f})
     powt = T(10)^f
-    xi = checked_mul(x, powt)
-    yi = y.i
+    xi, yi = checked_mul(x, powt), y.i
     quotient, remainder = divrem(xi, yi)
     reinterpret(FD{T, f}, quotient * powt + round(T, remainder / yi * powt))
 end
 
 function /{T, f}(x::FD{T, f}, y::Integer)
     powt = T(10)^f
-    xi = x.i
-    yi = checked_mul(y, powt)
+    xi, yi = x.i, checked_mul(y, powt)
     quotient, remainder = divrem(xi, yi)
     reinterpret(FD{T, f}, quotient * powt + round(T, remainder / yi * powt))
 end

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -144,8 +144,21 @@ function /{T, f}(x::FD{T, f}, y::FD{T, f})
 end
 
 # these functions are needed to avoid InexactError when converting from the integer type
-/{T, f}(x::Integer, y::FD{T, f}) = reinterpret(FD{T, f}, round(T, x / y.i))
-/{T, f}(x::FD{T, f}, y::Integer) = reinterpret(FD{T, f}, round(T, x.i / y))
+function /{T, f}(x::Integer, y::FD{T, f})
+    powt = T(10)^f
+    xi = widemul(x, powt)
+    yi = y.i
+    quotient, remainder = divrem(xi, yi)
+    reinterpret(FD{T, f}, quotient * powt + round(T, remainder / yi * powt))
+end
+
+function /{T, f}(x::FD{T, f}, y::Integer)
+    powt = T(10)^f
+    xi = x.i
+    yi = widemul(y, powt)
+    quotient, remainder = divrem(xi, yi)
+    reinterpret(FD{T, f}, quotient * powt + round(T, remainder / yi * powt))
+end
 
 # integerification
 trunc{T, f}(x::FD{T, f}) = FD{T, f}(div(x.i, T(10)^f))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -245,6 +245,24 @@ end
         @test_throws DivideError x/FD2(0)
     end
 
+    @testset "rounding" begin
+        # RoundNearest: 1.27 / 2 == 0.635 rounds up to 0.64
+        @test FD2(1.27) / FD2(2) == FD2(0.64)
+        @test FD2(-1.27) / FD2(2) == FD2(-0.64)
+        @test FD2(1.27) / 2 == FD2(0.64)
+        @test FD2(-1.27) / 2 == FD2(-0.64)
+        @test 127 / FD2(200) == FD2(0.64)
+        @test -127 / FD2(200) == FD2(-0.64)
+
+        # RoundNearest: 1.29 / 2 == 0.645 rounds down to 0.64
+        @test FD2(1.29) / FD2(2) == FD2(0.64)
+        @test FD2(-1.29) / FD2(2) == FD2(-0.64)
+        @test FD2(1.29) / 2 == FD2(0.64)
+        @test FD2(-1.29) / 2 == FD2(-0.64)
+        @test 129 / FD2(200) == FD2(0.64)
+        @test -129 / FD2(200) == FD2(-0.64)
+    end
+
     @testset "without promotion" begin
         @test_throws InexactError FD{Int8,1}(20)
         @test 20 / FD{Int8,1}(2) == FD{Int8,1}(10.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,6 +186,12 @@ end
         end
         @test prod(keyvalues[T]) == 0
     end
+
+    @testset "without promotion" begin
+        @test_throws InexactError FD{Int8,1}(20)
+        @test 20 * FD{Int8,1}(0.1) == FD{Int8,1}(2.0)
+        @test FD{Int8,1}(0.1) * 20 == FD{Int8,1}(2.0)
+    end
 end
 
 @testset "division" begin
@@ -237,6 +243,12 @@ end
 
     @testset "divide $x by 0" for x in keyvalues[FD2]
         @test_throws DivideError x/FD2(0)
+    end
+
+    @testset "without promotion" begin
+        @test_throws InexactError FD{Int8,1}(20)
+        @test 20 / FD{Int8,1}(2) == FD{Int8,1}(10.0)
+        @test FD{Int8,1}(2) / 20 == FD{Int8,1}(0.1)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -261,6 +261,18 @@ end
         @test FD2(-1.29) / 2 == FD2(-0.64)
         @test 129 / FD2(200) == FD2(0.64)
         @test -129 / FD2(200) == FD2(-0.64)
+
+        # Use of Float or BigFloat internally can change the calculated result
+        @test round(Int, 109 / 200 * 100) == 55
+        @test round(Int, BigInt(109) / 200 * 100) == 54  # Correct
+
+        x = FD{Int128,2}(1.09)
+        @test x / Int128(2) != x / BigInt(2)
+        @test x / FD{Int128,2}(2) == x / Int128(2)
+
+        y = FD{Int128,2}(200)
+        @test Int128(109) / y != BigInt(109) / y
+        @test FD{Int128,2}(109) / y == Int128(109) / y
     end
 
     @testset "without promotion" begin


### PR DESCRIPTION
Previously division would work by promotion but in some cases the integer provided would be outside of the range supported by the FixedDecimal:

```julia
julia> FD{Int8,1}(2) / FD{Int8,1}(10)
FixedDecimal{Int8,1}(0.2)

julia> FD{Int8,1}(2) / FD{Int8,1}(20)
ERROR: InexactError()
 in convert at /Users/omus/.julia/v0.5/FixedPointDecimals/src/FixedPointDecimals.jl:207 [inlined]
 in FixedPointDecimals.FixedDecimal{Int8,1}(::Int64) at ./sysimg.jl:53

julia> FD{Int8,1}(2) / 20  # With this PR
FixedDecimal{Int8,1}(0.1)
```