### PR TITLE
Avoid overflow when working with `powt`

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -204,8 +204,9 @@ function round{T, f}(::Type{FD{T, f}}, x::Rational,
 end
 
 # conversions and promotions
-convert{T, f}(::Type{FD{T, f}}, x::Integer) =
-    reinterpret(FD{T, f}, round(T, Base.widemul(T(x), T(10)^f)))
+function convert{T, f}(::Type{FD{T, f}}, x::Integer)
+    reinterpret(FD{T, f}, T(widemul(x, coefficient(FD{T, f}))))
+end
 
 convert{T <: FD}(::Type{T}, x::AbstractFloat) = round(T, x)
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -253,8 +253,7 @@ function convert{TI <: Integer, T, f}(::Type{TI}, x::FD{T, f})::TI
     div(x.i, coefficient(FD{T, f}))
 end
 
-convert{TR<:Rational,T,f}(::Type{TR}, x::FD{T, f})::TR =
-    x.i // T(10)^f
+convert{TR <: Rational, T, f}(::Type{TR}, x::FD{T, f})::TR = x.i // coefficient(FD{T, f})
 
 promote_rule{T, f, TI <: Integer}(::Type{FD{T, f}}, ::Type{TI}) = FD{T, f}
 promote_rule{T, f, TF <: AbstractFloat}(::Type{FD{T, f}}, ::Type{TF}) = TF

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -283,7 +283,7 @@ function print{T, f}(io::IO, x::FD{T, f})
 
     # note: a is negative if x.i == typemin(x.i)
     s, a = sign(x.i), abs(x.i)
-    integer, fractional = divrem(a, T(10)^f)
+    integer, fractional = divrem(a, exp10(T, f))
     integer = abs(integer)  # ...but since f > 0, this is positive
     fractional = abs(fractional)
 
@@ -380,6 +380,17 @@ function parse_round{T}(::Type{T}, fractional::AbstractString, ::RoundingMode{:N
         end
     end
     return T(0)
+end
+
+function exp10_max{T}(::Type{T})
+    length(digits(typemax(T))) - 1
+end
+
+function exp10(T::Type, y::Integer)
+    while T != BigInt && exp10_max(T) < y
+        T = widen(T)
+    end
+    T(10)^y
 end
 
 end

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -408,7 +408,8 @@ T or wider.
     end
 end
 
-coefficient{T, f}(fd::FD{T, f}) = widen(exp10(FD{T, f}))
+coefficient{T, f}(::Type{FD{T, f}}) = exp10(FD{T, f})
+coefficient{T, f}(fd::FD{T, f}) = coefficient(FD{T, f})
 value(fd::FD) = fd.i
 
 end

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -190,11 +190,11 @@ for fn in [:trunc, :floor, :ceil]
         reinterpret(FD{T, f}, val)
     end
 end
-round{TI <: Integer}(::Type{TI}, x::FD,
-                     ::RoundingMode{:Nearest}=RoundNearest)::TI = round(x)
-function round{T, f}(::Type{FD{T, f}}, x::Real,
-                     ::RoundingMode{:Nearest}=RoundNearest)
-    reinterpret(FD{T, f}, round(T, T(10)^f * x))
+function round{TI <: Integer}(::Type{TI}, x::FD, ::RoundingMode{:Nearest}=RoundNearest)::TI
+    round(x)
+end
+function round{T, f}(::Type{FD{T, f}}, x::Real, ::RoundingMode{:Nearest}=RoundNearest)
+    reinterpret(FD{T, f}, round(T, x * coefficient(FD{T, f})))
 end
 
 # needed to avoid ambiguity

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -161,7 +161,7 @@ function /{T, f}(x::FD{T, f}, y::Integer)
 end
 
 # integerification
-trunc{T, f}(x::FD{T, f}) = FD{T, f}(div(x.i, T(10)^f))
+trunc{T, f}(x::FD{T, f}) = FD{T, f}(div(x.i, coefficient(FD{T, f})))
 floor{T, f}(x::FD{T, f}) = FD{T, f}(fld(x.i, T(10)^f))
 # TODO: round with number of digits; should be easy
 function round{T, f}(x::FD{T, f}, ::RoundingMode{:Nearest}=RoundNearest)

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -250,7 +250,7 @@ end
 
 function convert{TI <: Integer, T, f}(::Type{TI}, x::FD{T, f})::TI
     isinteger(x) || throw(InexactError())
-    div(x.i, T(10)^f)
+    div(x.i, coefficient(FD{T, f}))
 end
 
 convert{TR<:Rational,T,f}(::Type{TR}, x::FD{T, f})::TR =

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -128,8 +128,8 @@ end
 # TODO: can we use floating point to speed this up? after we build a
 # correctness test suite.
 function *{T, f}(x::FD{T, f}, y::FD{T, f})
-    powt = T(10)^f
-    quotient, remainder = fldmod(Base.widemul(x.i, y.i), powt)
+    powt = coefficient(FD{T,f})
+    quotient, remainder = fldmod(widemul(x.i, y.i), powt)
     reinterpret(FD{T, f}, _round_to_even(quotient, remainder, powt))
 end
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -128,7 +128,7 @@ end
 # TODO: can we use floating point to speed this up? after we build a
 # correctness test suite.
 function *{T, f}(x::FD{T, f}, y::FD{T, f})
-    powt = coefficient(FD{T,f})
+    powt = coefficient(FD{T, f})
     quotient, remainder = fldmod(widemul(x.i, y.i), powt)
     reinterpret(FD{T, f}, _round_to_even(quotient, remainder, powt))
 end
@@ -139,7 +139,7 @@ end
 *{T, f}(x::FD{T, f}, y::Integer) = reinterpret(FD{T, f}, T(x.i * y))
 
 function /{T, f}(x::FD{T, f}, y::FD{T, f})
-    powt = coefficient(FD{T,f})
+    powt = coefficient(FD{T, f})
     quotient, remainder = divrem(x.i, y.i)
     reinterpret(FD{T, f}, T(widemul(quotient, powt) + round(T, remainder // y.i * powt)))
 end
@@ -147,14 +147,14 @@ end
 # These functions allow us to perform division with integers outside of the range of the
 # FixedDecimal.
 function /{T, f}(x::Integer, y::FD{T, f})
-    powt = coefficient(FD{T,f})
+    powt = coefficient(FD{T, f})
     xi, yi = widemul(x, powt), y.i
     quotient, remainder = divrem(xi, yi)
     reinterpret(FD{T, f}, T(quotient * powt + round(T, remainder // yi * powt)))
 end
 
 function /{T, f}(x::FD{T, f}, y::Integer)
-    powt = coefficient(FD{T,f})
+    powt = coefficient(FD{T, f})
     xi, yi = x.i, widemul(y, powt)
     quotient, remainder = divrem(xi, yi)
     reinterpret(FD{T, f}, T(quotient * powt + round(T, remainder // yi * powt)))

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -211,12 +211,8 @@ end
 convert{T <: FD}(::Type{T}, x::AbstractFloat) = round(T, x)
 
 function convert{T, f}(::Type{FD{T, f}}, x::Rational)::FD{T, f}
-    powt = T(10)^f
-    num::T, den::T = numerator(x), denominator(x)
-    g = gcd(powt, den)
-    powt = div(powt, g)
-    den = div(den, g)
-    reinterpret(FD{T, f}, powt * num) / FD{T, f}(den)
+    powt = coefficient(FD{T, f})
+    reinterpret(FD{T, f}, T(x * powt))
 end
 
 function convert{T, f, U, g}(::Type{FD{T, f}}, x::FD{U, g})

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -32,7 +32,7 @@ using Compat
 import Base: reinterpret, zero, one, abs, sign, ==, <, <=, +, -, /, *, div, rem, divrem,
              fld, mod, fldmod, fld1, mod1, fldmod1, isinteger, typemin, typemax,
              realmin, realmax, print, show, string, convert, parse, promote_rule, min, max,
-             trunc, round, floor, ceil, eps, float, widemul, exp10
+             trunc, round, floor, ceil, eps, float, widemul
 
 import Base.Checked: checked_mul
 
@@ -414,22 +414,6 @@ function max_exp10{T <: Integer}(::Type{T})
     end
 
     exponent - 1
-end
-
-"""
-    exp10(::Type{FD{T, f}})
-
-Compute `10^f` as an Integer without overflow. The resulting type will be an integer of type
-T or wider.
-"""
-@generated function exp10{T <: Integer, f}(::Type{FD{T, f}})
-    P = T
-    while P != BigInt && f > max_exp10(P)
-        P = widen(P)
-    end
-    quote
-        $(P(10)^f)
-    end
 end
 
 """

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -171,7 +171,7 @@ function round{T, f}(x::FD{T, f}, ::RoundingMode{:Nearest}=RoundNearest)
     FD{T, f}(_round_to_even(quotient, remainder, powt))
 end
 function ceil{T, f}(x::FD{T, f})
-    powt = T(10)^f
+    powt = coefficient(FD{T, f})
     quotient, remainder = fldmod(x.i, powt)
     if remainder > 0
         FD{T, f}(quotient + one(quotient))

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -199,9 +199,8 @@ function round{T, f}(::Type{FD{T, f}}, x::Real, ::RoundingMode{:Nearest}=RoundNe
 end
 
 # needed to avoid ambiguity
-function round{T, f}(::Type{FD{T, f}}, x::Rational,
-                     ::RoundingMode{:Nearest}=RoundNearest)
-    reinterpret(FD{T, f}, round(T, T(10)^f * x))
+function round{T, f}(::Type{FD{T, f}}, x::Rational, ::RoundingMode{:Nearest}=RoundNearest)
+    reinterpret(FD{T, f}, round(T, x * coefficient(FD{T, f})))
 end
 
 # conversions and promotions

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -271,7 +271,7 @@ Base.@pure promote_rule{T, f, U, g}(::Type{FD{T, f}}, ::Type{FD{U, g}}) =
 <={T <: FD}(x::T, y::T) = x.i <= y.i
 
 # predicates and traits
-isinteger{T, f}(x::FD{T, f}) = rem(x.i, T(10)^f) == 0
+isinteger{T, f}(x::FD{T, f}) = rem(x.i, coefficient(FD{T, f})) == 0
 typemin{T, f}(::Type{FD{T, f}}) = reinterpret(FD{T, f}, typemin(T))
 typemax{T, f}(::Type{FD{T, f}}) = reinterpret(FD{T, f}, typemax(T))
 eps{T <: FD}(::Type{T}) = reinterpret(T, 1)

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -162,7 +162,8 @@ end
 
 # integerification
 trunc{T, f}(x::FD{T, f}) = FD{T, f}(div(x.i, coefficient(FD{T, f})))
-floor{T, f}(x::FD{T, f}) = FD{T, f}(fld(x.i, T(10)^f))
+floor{T, f}(x::FD{T, f}) = FD{T, f}(fld(x.i, coefficient(FD{T, f})))
+
 # TODO: round with number of digits; should be easy
 function round{T, f}(x::FD{T, f}, ::RoundingMode{:Nearest}=RoundNearest)
     powt = T(10)^f

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -393,7 +393,19 @@ end
 The highest value of `x` which does not result in an overflow when evaluating `T(10)^x`.
 """
 function max_exp10{T <: Integer}(::Type{T})
-    length(digits(typemax(T))) - 1
+    W = widen(T)
+    type_max = W(typemax(T))
+
+    powt = one(W)
+    ten = W(10)
+    exponent = 0
+
+    while type_max > powt
+        powt *= ten
+        exponent += 1
+    end
+
+    exponent - 1
 end
 
 """

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -185,7 +185,7 @@ for fn in [:trunc, :floor, :ceil]
     # round/trunc/ceil/flooring to FD; generic
     # TODO. we may need to check overflow and boundary conditions here.
     @eval function $fn{T, f}(::Type{FD{T, f}}, x::Real)
-        powt = T(10)^f
+        powt = coefficient(FD{T, f})
         val = trunc(T, $(Symbol(fn, "mul"))(x, powt))
         reinterpret(FD{T, f}, val)
     end

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -240,8 +240,13 @@ for divfn in [:div, :fld, :fld1]
 end
 
 convert(::Type{AbstractFloat}, x::FD) = convert(floattype(typeof(x)), x)
-convert{TF <: AbstractFloat, T, f}(::Type{TF}, x::FD{T, f})::TF =
-    x.i / TF(10)^f
+function convert{TF <: AbstractFloat, T, f}(::Type{TF}, x::FD{T, f})::TF
+    x.i / coefficient(FD{T, f})
+end
+
+function convert{TF <: BigFloat, T, f}(::Type{TF}, x::FD{T, f})::TF
+    BigInt(x.i) / BigInt(coefficient(FD{T, f}))
+end
 
 function convert{TI <: Integer, T, f}(::Type{TI}, x::FD{T, f})::TI
     isinteger(x) || throw(InexactError())

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -138,26 +138,26 @@ end
 *{T, f}(x::Integer, y::FD{T, f}) = reinterpret(FD{T, f}, T(x * y.i))
 *{T, f}(x::FD{T, f}, y::Integer) = reinterpret(FD{T, f}, T(x.i * y))
 
-# TODO. this is probably wrong sometimes.
 function /{T, f}(x::FD{T, f}, y::FD{T, f})
     powt = coefficient(FD{T,f})
     quotient, remainder = divrem(x.i, y.i)
     reinterpret(FD{T, f}, T(widemul(quotient, powt) + round(T, remainder // y.i * powt)))
 end
 
-# these functions are needed to avoid InexactError when converting from the integer type
+# These functions allow us to perform division with integers outside of the range of the
+# FixedDecimal.
 function /{T, f}(x::Integer, y::FD{T, f})
     powt = coefficient(FD{T,f})
-    xi, yi = checked_mul(x, powt), y.i
+    xi, yi = widemul(x, powt), y.i
     quotient, remainder = divrem(xi, yi)
-    reinterpret(FD{T, f}, T(widemul(quotient, powt) + round(T, remainder // yi * powt)))
+    reinterpret(FD{T, f}, T(quotient * powt + round(T, remainder // yi * powt)))
 end
 
 function /{T, f}(x::FD{T, f}, y::Integer)
     powt = coefficient(FD{T,f})
-    xi, yi = x.i, checked_mul(y, powt)
+    xi, yi = x.i, widemul(y, powt)
     quotient, remainder = divrem(xi, yi)
-    reinterpret(FD{T, f}, T(widemul(quotient, powt) + round(T, remainder // yi * powt)))
+    reinterpret(FD{T, f}, T(quotient * powt + round(T, remainder // yi * powt)))
 end
 
 # integerification

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -140,24 +140,24 @@ end
 
 # TODO. this is probably wrong sometimes.
 function /{T, f}(x::FD{T, f}, y::FD{T, f})
-    powt = T(10)^f
+    powt = coefficient(FD{T,f})
     quotient, remainder = divrem(x.i, y.i)
-    reinterpret(FD{T, f}, quotient * powt + round(T, remainder / y.i * powt))
+    reinterpret(FD{T, f}, T(widemul(quotient, powt) + round(T, remainder // y.i * powt)))
 end
 
 # these functions are needed to avoid InexactError when converting from the integer type
 function /{T, f}(x::Integer, y::FD{T, f})
-    powt = T(10)^f
+    powt = coefficient(FD{T,f})
     xi, yi = checked_mul(x, powt), y.i
     quotient, remainder = divrem(xi, yi)
-    reinterpret(FD{T, f}, quotient * powt + round(T, remainder / yi * powt))
+    reinterpret(FD{T, f}, T(widemul(quotient, powt) + round(T, remainder // yi * powt)))
 end
 
 function /{T, f}(x::FD{T, f}, y::Integer)
-    powt = T(10)^f
+    powt = coefficient(FD{T,f})
     xi, yi = x.i, checked_mul(y, powt)
     quotient, remainder = divrem(xi, yi)
-    reinterpret(FD{T, f}, quotient * powt + round(T, remainder / yi * powt))
+    reinterpret(FD{T, f}, T(widemul(quotient, powt) + round(T, remainder // yi * powt)))
 end
 
 # integerification

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -166,7 +166,7 @@ floor{T, f}(x::FD{T, f}) = FD{T, f}(fld(x.i, coefficient(FD{T, f})))
 
 # TODO: round with number of digits; should be easy
 function round{T, f}(x::FD{T, f}, ::RoundingMode{:Nearest}=RoundNearest)
-    powt = T(10)^f
+    powt = coefficient(FD{T, f})
     quotient, remainder = fldmod(x.i, powt)
     FD{T, f}(_round_to_even(quotient, remainder, powt))
 end

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -82,7 +82,8 @@ immutable FixedDecimal{T <: Integer, f} <: Real
 
     # inner constructor
     function Base.reinterpret{T, f}(::Type{FixedDecimal{T, f}}, i::Integer)
-        if T != BigInt && 0 <= f <= max_exp10(T) || T == BigInt && f >= 0
+        n = max_exp10(T)
+        if f >= 0 && (n < 0 || f <= n)
             new{T, f}(i % T)
         else
             throw(ArgumentError(
@@ -398,9 +399,11 @@ end
 """
     max_exp10(T)
 
-The highest value of `x` which does not result in an overflow when evaluating `T(10)^x`.
+The highest value of `x` which does not result in an overflow when evaluating `T(10)^x`. For
+types of `T` that do not overflow -1 will be returned.
 """
 function max_exp10{T <: Integer}(::Type{T})
+    applicable(typemax, T) || return -1
     W = widen(T)
     type_max = W(typemax(T))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -435,6 +435,31 @@ end
         # to FD2
         @test x == round(FD2, x)
     end
+
+    @testset "limits" begin
+        for T in CONTAINER_TYPES
+            f = FixedPointDecimals.max_exp10(T) + 1
+            @eval begin
+                powt = FixedPointDecimals.coefficient(FD{$T,$f})
+
+                max_rounded = round($T, typemax($T) / powt)
+                min_rounded = round($T, typemin($T) / powt)
+
+                # Note: all values `x` in FD{T,f} are -1 < x < 1
+                if max_rounded > 0
+                    @test_throws InexactError round(reinterpret(FD{$T,$f}, typemax($T)))
+                else
+                    @test round(reinterpret(FD{$T,$f}, typemax($T))) == FD{$T,$f}(max_rounded)
+                end
+
+                if min_rounded < 0
+                    @test_throws InexactError round(reinterpret(FD{$T,$f}, typemin($T)))
+                else
+                    @test round(reinterpret(FD{$T,$f}, typemin($T))) == FD{$T,$f}(min_rounded)
+                end
+            end
+        end
+    end
 end
 
 @testset "trunc" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -581,6 +581,14 @@ epsi{T}(::Type{T}) = eps(T)
 
                 @test value(ceil(FD{$T,$f}, max_dec)) in [max_int, signed(widen(max_int)) + 1]
                 @test value(ceil(FD{$T,$f}, min_dec)) in [min_int, min_int + 1]
+
+                # Note: all values `x` in FD{T,f} are -1 < x < 1
+                @test floor(reinterpret(FD{$T,$f}, typemax($T))) == zero(FD{$T,$f})
+                if $T <: Unsigned
+                    @test floor(reinterpret(FD{$T,$f}, typemin($T))) == zero(FD{$T,$f})
+                else
+                    @test_throws InexactError floor(reinterpret(FD{$T,$f}, typemin($T)))
+                end
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,21 @@ if VERSION < v"0.6.0-dev.1849"
     Base.:/(x::UInt128, y::BigInt) = /(promote(x, y)...)
 end
 
+@testset "max_exp10" begin
+    @test FixedPointDecimals.max_exp10(Int8) == 2
+    @test FixedPointDecimals.max_exp10(Int64) == 18
+    @test FixedPointDecimals.max_exp10(Int128) == 38
+    @test FixedPointDecimals.max_exp10(UInt8) == 2
+    @test FixedPointDecimals.max_exp10(UInt64) == 19
+    @test FixedPointDecimals.max_exp10(UInt128) == 38
+    @test_throws MethodError FixedPointDecimals.max_exp10(BigInt)
+
+    for T in CONTAINER_TYPES
+        x = FixedPointDecimals.max_exp10(T)
+        @test T(10)^x == widen(T(10))^x
+    end
+end
+
 # ensure that the coefficient multiplied by the highest and lowest representable values of
 # the container type do not result in overflow.
 @testset "coefficient" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,6 +114,11 @@ end
         @test convert(BigFloat, fd) == BigInt(val) / BigInt(powt)
     end
 
+    @testset "to rational" begin
+        fd = reinterpret(FD2, 25)
+        @test convert(Rational, fd) == 1//4
+    end
+
     @testset "invalid" begin
         @test_throws InexactError convert(FD2, FD4(0.0001))
         @test_throws InexactError convert(FD4, typemax(FD2))
@@ -153,6 +158,13 @@ end
         @test convert(Float32, fd)  == Float32(typemin(T) / powt)
         @test convert(Float64, fd)  == Float64(typemin(T) / powt)
         @test convert(BigFloat, fd) == BigInt(typemin(T)) / powt
+
+        # Converting to a rational
+        fd = reinterpret(FD{T,f}, typemax(T))
+        @test convert(Rational, fd)  == typemax(T) // powt
+
+        fd = reinterpret(FD{T,f}, typemin(T))
+        @test convert(Rational, fd)  == typemin(T) // powt
 
         # Adjust number of decimal places allowed so we can have `-10 < x < 10` where x is
         # a FD{T,f}. Only needed to test `convert(::FD, ::Integer)`

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -589,6 +589,9 @@ epsi{T}(::Type{T}) = eps(T)
                 else
                     @test_throws InexactError floor(reinterpret(FD{$T,$f}, typemin($T)))
                 end
+
+                @test_throws InexactError ceil(reinterpret(FD{$T,$f}, typemax($T)))
+                @test ceil(reinterpret(FD{$T,$f}, typemin($T))) == zero(FD{$T,$f})
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,6 +101,14 @@ end
     end
 end
 
+@testset "constructor" begin
+    @testset "invalid $T" for T in CONTAINER_TYPES
+        f = FixedPointDecimals.max_exp10(T) + 1
+        @test_throws ArgumentError reinterpret(FD{T,f}, 0)
+        @test_throws ArgumentError reinterpret(FD{T,-1}, 0)
+    end
+end
+
 @testset "conversion" begin
     @testset for x in keyvalues[FD2]
         @testset for T in [Rational{Int128}, WFD2, WFD4]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,7 @@ end
         for j in i:length(CONTAINER_TYPES)
             f = FixedPointDecimals.max_exp10(CONTAINER_TYPES[j])
             powt = FixedPointDecimals.coefficient(FD{T, f})
+            @test powt % 10 == 0
             @test checked_mul(widen(powt), typemax(T)) == widemul(powt, typemax(T))
             @test checked_mul(widen(powt), typemin(T)) == widemul(powt, typemin(T))
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,6 +229,27 @@ end
         @test 20 * FD{Int8,1}(0.1) == FD{Int8,1}(2.0)
         @test FD{Int8,1}(0.1) * 20 == FD{Int8,1}(2.0)
     end
+
+    @testset "limits" begin
+        for T in CONTAINER_TYPES
+            x = FixedPointDecimals.max_exp10(T)
+            f = x + 1
+
+            @eval begin
+                scalar = reinterpret(FD{$T,$f}, $T(10)^$x)  # 0.1
+
+                # Since multiply will round the result we'll make sure our value does not
+                # always rounds down.
+                max_int = typemax($T) - (typemax($T) % 10)
+                min_int = typemin($T) - (typemin($T) % 10)
+
+                @test reinterpret(FD{$T,$f}, max_int) * scalar ==
+                    reinterpret(FD{$T,$f}, div(max_int, 10))
+                @test reinterpret(FD{$T,$f}, min_int) * scalar ==
+                    reinterpret(FD{$T,$f}, div(min_int, 10))
+            end
+        end
+    end
 end
 
 @testset "division" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -424,6 +424,12 @@ end
     @test string(FD2(-0.01)) == "-0.01"
     @test string(FD2(0)) == "0.00"
     @test string(FixedDecimal{Int,0}(123.4)) == "123"
+
+    # Displaying a decimal could be incorrect when using a decimal place precision which is
+    # close to or at the limit the limit for our storage type. Int32 for example can only
+    # store up to 10 digits of precision.
+    @test string(reinterpret(FD{Int32,10}, typemax(Int32))) ==  "0.2147483647"
+    @test string(reinterpret(FD{Int32,10}, typemin(Int32))) == "-0.2147483648"
 end
 
 @testset "show" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -341,12 +341,12 @@ end
 
     @testset "without promotion" begin
         @test_throws InexactError FD{Int8,1}(20)
-        @test 20 / FD{Int8,1}(2) == FD{Int8,1}(10.0)
-        @test FD{Int8,1}(2) / 20 == FD{Int8,1}(0.1)
+        @test Int8(20) / FD{Int8,1}(2) == FD{Int8,1}(10.0)
+        @test FD{Int8,1}(2) / Int8(20) == FD{Int8,1}(0.1)
     end
 
     @testset "limits" begin
-        @test_throws InexactError 1 / FD{Int8,2}(0.4)
+        @test_throws InexactError Int8(1) / FD{Int8,2}(0.4)
         @test_throws InexactError FD{Int8,2}(1) / FD{Int8,2}(0.4)
 
         for T in CONTAINER_TYPES
@@ -365,13 +365,13 @@ end
             @eval begin
                 @test ($max_fd * $scalar) / $scalar == $max_fd
                 @test ($min_fd * $scalar) / $scalar == $min_fd
-                @test $max_fd / 2 == reinterpret(FD{$T,$f}, div($max_int, 2))
-                @test $min_fd / 2 == reinterpret(FD{$T,$f}, div($min_int, 2))
+                @test $max_fd / $T(2) == reinterpret(FD{$T,$f}, div($max_int, 2))
+                @test $min_fd / $T(2) == reinterpret(FD{$T,$f}, div($min_int, 2))
 
                 # Since the precision of `f` doesn't allow us to make a FixedDecimal >= 1
                 # there is no way testing this function without raising an exception.
-                $max_fd != 0 && @test_throws InexactError 2 / $max_fd
-                $min_fd != 0 && @test_throws InexactError 2 / $min_fd
+                $max_fd != 0 && @test_throws InexactError $T(2) / $max_fd
+                $min_fd != 0 && @test_throws InexactError $T(2) / $min_fd
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -481,6 +481,10 @@ end
                 # we can have the expected result be a little flexible.
                 @test value(trunc(FD{$T,$f}, max_int / powt)) in [max_int, max_int - 1]
                 @test value(trunc(FD{$T,$f}, min_int / powt)) in [min_int, min_int + 1]
+
+                # Note: all values `x` in FD{T,f} are -1 < x < 1
+                @test trunc(reinterpret(FD{$T,$f}, typemax($T))) == zero(FD{$T,$f})
+                @test trunc(reinterpret(FD{$T,$f}, typemin($T))) == zero(FD{$T,$f})
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,7 +81,7 @@ end
     @test FixedPointDecimals.max_exp10(UInt8) == 2
     @test FixedPointDecimals.max_exp10(UInt64) == 19
     @test FixedPointDecimals.max_exp10(UInt128) == 38
-    @test_throws MethodError FixedPointDecimals.max_exp10(BigInt)
+    @test FixedPointDecimals.max_exp10(BigInt) == -1
 
     for T in CONTAINER_TYPES
         x = FixedPointDecimals.max_exp10(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,24 @@ end
                 @test convert(FD{$T,$f}, $(max_int / powt)).i == $max_int
                 @test $min_int >= typemin($T)
                 @test convert(FD{$T,$f}, $(min_int / powt)).i == $min_int
+
+                @test_throws InexactError convert(FD{$T,$f}, $T(1))
+            end
+        end
+
+        for T in CONTAINER_TYPES
+            f = FixedPointDecimals.max_exp10(T)
+            powt = FixedPointDecimals.coefficient(FD{T,f})
+
+            max_int = typemax(T) ÷ powt * powt
+            min_int = typemin(T) ÷ powt * powt
+
+            @eval begin
+                @test convert(FD{$T,$f}, $(max_int ÷ powt)) == reinterpret(FD{$T,$f}, $max_int)
+                @test convert(FD{$T,$f}, $(min_int ÷ powt)) == reinterpret(FD{$T,$f}, $min_int)
+
+                @test_throws InexactError convert(FD{$T,$f}, $(max_int ÷ powt) + $T(1))
+                @test_throws InexactError convert(FD{$T,$f}, $(min_int ÷ powt) - $T(1))  # Overflows with Unsigned
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -372,8 +372,7 @@ end
             @test trunc(FD3, x) == FD3(x - 0.001)
 
             for f in 0:12
-                @test trunc(FD{Int64, f}, x) ==
-                      parse_int(FD{Int64, f}, INTS[x])
+                @test trunc(FD{Int64, f}, x) == parse_int(FD{Int64, f}, INTS[x])
             end
         end
 
@@ -410,8 +409,7 @@ epsi{T}(::Type{T}) = eps(T)
             @test floor(FD3, x) == FD3(x - 0.001)
 
             for f in 0:12
-                @test floor(FD{Int64, f}, x) ==
-                      parse_int(FD{Int64, f}, INTS[x])
+                @test floor(FD{Int64, f}, x) == parse_int(FD{Int64, f}, INTS[x])
             end
 
             @test ceil(FD3, x) == ceil(FD4, x) == FD4(x)
@@ -423,8 +421,7 @@ epsi{T}(::Type{T}) = eps(T)
             @test ceil(FD3, x) == FD3(x + 0.001)
 
             for f in 0:12
-                @test ceil(FD{Int64, f}, x) ==
-                      parse_int(FD{Int64, f}, INTS[x], ceil=true)
+                @test ceil(FD{Int64, f}, x) == parse_int(FD{Int64, f}, INTS[x], ceil=true)
             end
 
             @test floor(FD3, x) == floor(FD4, x) == FD4(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -458,6 +458,26 @@ end
     end
 end
 
+@testset "isinteger" begin
+    @testset "overflow" begin
+        # Note: After overflow `Int8(10)^6 == 64`
+        @test !isinteger(reinterpret(FD{Int8,6}, 64))  # 0.000064
+    end
+
+    @testset "limits of $T" for T in CONTAINER_TYPES
+        f = FixedPointDecimals.max_exp10(T)
+
+        max_fd = typemax(FD{T,f})
+        min_fd = typemin(FD{T,f})
+
+        @test !isinteger(max_fd)
+        @test isinteger(trunc(max_fd))
+
+        @test isinteger(min_fd) == (min_fd == zero(min_fd))
+        @test isinteger(trunc(min_fd))
+    end
+end
+
 @testset "round" begin
     @testset "to Int" begin
         @test round(Int, FD2(-0.51)) === -1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,10 +116,13 @@ end
         @test min_int >= typemin(T)
         @test value(convert(FD{T,f}, min_int / powt)) == min_int
 
+        @test convert(FD{T,f}, typemax(T) // powt) == reinterpret(FD{T,f}, typemax(T))
+        @test convert(FD{T,f}, typemin(T) // powt) == reinterpret(FD{T,f}, typemin(T))
+
         @test_throws InexactError convert(FD{T,f}, T(1))
 
         # Adjust number of decimal places allowed so we can have `-10 < x < 10` where x is
-        # a FD{T,f}.
+        # a FD{T,f}. Only needed to test `convert(::FD, ::Integer)`
         f = FixedPointDecimals.max_exp10(T)
         powt = FixedPointDecimals.coefficient(FD{T,f})
 
@@ -136,6 +139,8 @@ end
     @test_throws InexactError convert(FD2, FD4(0.0001))
     @test_throws InexactError convert(FD4, typemax(FD2))
     @test_throws InexactError convert(SFD2, typemax(FD2))
+    @test_throws InexactError convert(FD2, 1//3)
+    @test_throws InexactError convert(FD{Int8,1}, 1//4)
 end
 
 @testset "promotion" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,9 +73,9 @@ end
     for (i, T) in enumerate(CONTAINER_TYPES)
         for j in i:length(CONTAINER_TYPES)
             f = FixedPointDecimals.max_exp10(CONTAINER_TYPES[j])
-            powt = FixedPointDecimals.coefficient(FD{T, f}(0))
-            @test checked_mul(powt, typemax(T)) == powt * typemax(T)
-            @test checked_mul(powt, typemin(T)) == powt * typemin(T)
+            powt = FixedPointDecimals.coefficient(FD{T, f})
+            @test checked_mul(widen(powt), typemax(T)) == widemul(powt, typemax(T))
+            @test checked_mul(widen(powt), typemin(T)) == widemul(powt, typemin(T))
         end
     end
 end


### PR DESCRIPTION
Several of the `FixedDecimal{T,f}` functions used `T(10)^f` to compute `10ᶠ`. This calculation can easily run into overflow especially if the storage type `T` is small and number of places to store `f` is large.

For example, given `T = Int8` which has a `typemax(Int8) = 127` and `f = 3` if we attempt to compute `powt = T(10)^f` we end up with `-24` instead of `1000`. Using the `powt` value during calculations can cause the resulting FixedDecimal to be incorrect which is very bad for library whose purpose is to have more accurate calculations than floating-point.

I've revised the code to make use of a new function `coefficient(::Type{FD{T,f}})` which calculates `powt` without ever overflowing. Additionally, since none of these scenarios were previously tested I added several new testsets to ensure the overflow issues are not reintroduced. Finally, these changes found some additional problems regarding FixedDecimal division which no longer uses an intermediate floating-point number.