### PR TITLE
Fix overflow issues with division

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -115,7 +115,7 @@ Round `quotient + remainder / divisor` to the nearest even integer, given that
 satisfied by the return value of `fldmod` in all cases, and the return value of
 `divrem` in cases where `divisor` is known to be positive.)
 """
-function _round_to_even(quotient, remainder, divisor)
+function _round_to_even{T <: Integer}(quotient::T, remainder::T, divisor::T)
     halfdivisor = divisor >> 1
     if iseven(divisor) && remainder == halfdivisor
         ifelse(iseven(quotient), quotient, quotient + one(quotient))
@@ -125,6 +125,7 @@ function _round_to_even(quotient, remainder, divisor)
         quotient
     end
 end
+_round_to_even(q, r, d) = _round_to_even(promote(q, r, d)...)
 
 # multiplication rounds to nearest even representation
 # TODO: can we use floating point to speed this up? after we build a

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -142,31 +142,21 @@ end
 
 function /{T, f}(x::FD{T, f}, y::FD{T, f})
     powt = T(10)^f
-    quotient, remainder = fldmod(widemul(x.i, powt), widen(y.i))
-    reinterpret(FD{T, f}, T(_round_to_even(quotient, remainder, widen(y.i))))
+    quotient, remainder = fldmod(widemul(x.i, powt), y.i)
+    reinterpret(FD{T, f}, T(_round_to_even(quotient, remainder, y.i)))
 end
 
 # these functions are needed to avoid InexactError when converting from the integer type
 function /{T, f}(x::Integer, y::FD{T, f})
-    S = promote_type(typeof(x), T)
-    xi, yi = promote(x, y.i)
-
-    # The integer part of our result is x.i * 10^2f / y.i, so we need to
-    # double-widen to get a precise result.
-    powt = S(10)^f
+    powt = T(10)^f
     powtsq = widemul(powt, powt)
-    quotient, remainder = fldmod(widemul(widen(xi), powtsq), widen(widen(yi)))
-
-    reinterpret(FD{T, f},
-                T(_round_to_even(quotient, remainder, widen(widen(yi)))))
+    quotient, remainder = fldmod(widemul(x, powtsq), y.i)
+    reinterpret(FD{T, f}, T(_round_to_even(quotient, remainder, y.i)))
 end
 
 function /{T, f}(x::FD{T, f}, y::Integer)
-    S = promote_type(T, typeof(y))
-    xi, yi = promote(x.i, y)
-
-    quotient, remainder = fldmod(xi, yi)
-    reinterpret(FD{T, f}, T(_round_to_even(quotient, remainder, yi)))
+    quotient, remainder = fldmod(x.i, y)
+    reinterpret(FD{T, f}, T(_round_to_even(quotient, remainder, y)))
 end
 
 # integerification

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,7 +198,13 @@ end
     @testset "division by 1" begin
         @testset for x in keyvalues[FD2]
             @test x / one(x) == x
-            @test x / -one(x) == -x
+
+             # signed integers using two's complement have one additional negative value
+            if x < 0 && x == typemin(x)
+                @test_throws InexactError x / -one(x)
+            else
+                @test x / -one(x) == -x
+            end
         end
     end
 
@@ -262,17 +268,18 @@ end
         @test 129 / FD2(200) == FD2(0.64)
         @test -129 / FD2(200) == FD2(-0.64)
 
-        # Use of Float or BigFloat internally can change the calculated result
+        # Use of Float or BigFloat internally should not change the calculated
+        # result
         @test round(Int, 109 / 200 * 100) == 55
         @test round(Int, BigInt(109) / 200 * 100) == 54  # Correct
 
         x = FD{Int128,2}(1.09)
-        @test x / Int128(2) != x / BigInt(2)
-        @test x / FD{Int128,2}(2) == x / Int128(2)
+        @test x / Int128(2) == x / BigInt(2) == FD2(0.54)
+        @test x / FD{Int128,2}(2) == x / Int128(2) == FD2(0.54)
 
         y = FD{Int128,2}(200)
-        @test Int128(109) / y != BigInt(109) / y
-        @test FD{Int128,2}(109) / y == Int128(109) / y
+        @test Int128(109) / y == BigInt(109) / y == FD2(0.54)
+        @test FD{Int128,2}(109) / y == Int128(109) / y == FD2(0.54)
     end
 
     @testset "without promotion" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -199,7 +199,7 @@ end
         @testset for x in keyvalues[FD2]
             @test x / one(x) == x
 
-             # signed integers using two's complement have one additional negative value
+            # signed integers using two's complement have one additional negative value
             if x < 0 && x == typemin(x)
                 @test_throws InexactError x / -one(x)
             else
@@ -268,18 +268,16 @@ end
         @test 129 / FD2(200) == FD2(0.64)
         @test -129 / FD2(200) == FD2(-0.64)
 
-        # Use of Float or BigFloat internally should not change the calculated
-        # result
+        # Use of Float or BigFloat internally should not change the calculated result
         @test round(Int, 109 / 200 * 100) == 55
         @test round(Int, BigInt(109) / 200 * 100) == 54  # Correct
 
-        x = FD{Int128,2}(1.09)
-        @test x / Int128(2) == x / BigInt(2) == FD2(0.54)
-        @test x / FD{Int128,2}(2) == x / Int128(2) == FD2(0.54)
-
-        y = FD{Int128,2}(200)
-        @test Int128(109) / y == BigInt(109) / y == FD2(0.54)
-        @test FD{Int128,2}(109) / y == Int128(109) / y == FD2(0.54)
+        x = FD2(1.09)
+        y = FD2(200)
+        for T in [FD2, Int8, Int128, BigInt]
+            @test x / T(2) == FD2(0.54)
+            @test T(109) / y == FD2(0.54)
+        end
     end
 
     @testset "without promotion" begin


### PR DESCRIPTION
Here is an alternative approach to fixing division that I think is cleaner (it's mostly orthogonal to the changes you propose in #8, but replaces the use of rational rounding, which as far as I can tell is susceptible to overflow errors that could be avoided). We may end up widening `Int64` to `BigInt` for the `Int64 / FD{Int64, f}` case, but that is hard to avoid while still being able to evaluate all divisions.