### PR TITLE
Fix float conversion overflow problems

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,15 +47,15 @@ const keyvalues = Dict(
 # Floating point values written as integer strings. Useful for testing behaviours of
 # trunc, floor, and ceil.
 const INTS = Dict(
-    1.22 => "12199999999999999733546474089962430298328399658203125",
-    1.23 => "1229999999999999982236431605997495353221893310546875",
-    1.51 => "15100000000000000088817841970012523233890533447265625",
-    2.2  => "220000000000000017763568394002504646778106689453125",
-    2.3  => "229999999999999982236431605997495353221893310546875"
+    v => replace(@sprintf("%.200f", v), ".", "")
+    for v in [
+        1.22,
+        1.23,
+        1.51,
+        2.2,
+        2.3,
+    ]
 )
-for (k, v) in INTS
-    INTS[k] = rpad(v, 201, "0")
-end
 const smaller_than_decimal = [1.22, 1.23, 2.3]
 const bigger_than_decimal = [1.51, 2.2]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,6 +53,9 @@ const INTS = Dict(
     2.2  => "220000000000000017763568394002504646778106689453125",
     2.3  => "229999999999999982236431605997495353221893310546875"
 )
+for (k, v) in INTS
+    INTS[k] = rpad(v, 201, "0")
+end
 const smaller_than_decimal = [1.22, 1.23, 2.3]
 const bigger_than_decimal = [1.51, 2.2]
 
@@ -603,15 +606,21 @@ end
             @test trunc(FD2, x) == FD2(x - 0.01)
             @test trunc(FD3, x) == FD3(x - 0.001)
 
-            for f in 0:12
+            for f in 0:18
                 @test trunc(FD{Int64, f}, x) == parse_int(FD{Int64, f}, INTS[x])
+            end
+            for f in 0:200
+                @test trunc(FD{BigInt, f}, x) == parse_int(FD{BigInt, f}, INTS[x])
             end
         end
 
         for x in bigger_than_decimal
             exactval = FD3(x)
-            for f in 3:12
+            for f in 3:14
                 @test trunc(FD{Int64, f}, x) == exactval
+            end
+            for f in 0:18
+                @test trunc(FD{Int64, f}, x) == parse_int(FD{Int64, f}, INTS[x])
             end
         end
     end
@@ -661,7 +670,7 @@ epsi{T}(::Type{T}) = eps(T)
             @test floor(FD2, x) == FD2(x - 0.01)
             @test floor(FD3, x) == FD3(x - 0.001)
 
-            for f in 0:12
+            for f in 0:18
                 @test floor(FD{Int64, f}, x) == parse_int(FD{Int64, f}, INTS[x])
             end
 
@@ -673,7 +682,7 @@ epsi{T}(::Type{T}) = eps(T)
             @test ceil(FD2, x) == FD2(x + 0.01)
             @test ceil(FD3, x) == FD3(x + 0.001)
 
-            for f in 0:12
+            for f in 0:18
                 @test ceil(FD{Int64, f}, x) == parse_int(FD{Int64, f}, INTS[x], ceil=true)
             end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,26 +1,13 @@
-# Format a floating-point number as a string with a specific precision. Similar to
-# `@sprintf("%.$(dp)f", val)`.
-
-if VERSION < v"0.6-"
-    function float_string(val::AbstractFloat, dp::Integer)
-        # On Julia 0.5 positive 0.0 can have extra bits. No other integer floating-point
-        # seems to have this problem.
-        isequal(val, 0.0) && return rpad("0.", dp, '0')
-        format = "%.$(dp)f"
-        @eval @sprintf($("%.$(dp)f"), nextfloat(0.0))
-        @eval begin
-            let buffer = Array{UInt8}(100 + $dp)
-                ccall((:snprintf, :libc), Int, (Ptr{UInt8}, Csize_t, Cstring, Cdouble), buffer, length(buffer), $format, $val)
-                unsafe_string(pointer(buffer))
-            end
-        end
+# Print the floating-point number with precision high enough that rounding never occurs
+function float_string(val::AbstractFloat)
+    # Note: This function could simply be `@sprintf("%.325f", val)` once the following
+    # issue is solved: https://github.com/JuliaLang/julia/issues/22137
+    dp = 325  # Number of decimal places to print `nextfloat(0.0)` without rounding
+    int = trunc(BigInt, val)
+    if abs(int) > 0
+        dp -= ndigits(int)
     end
-else
-    function float_string(val::AbstractFloat, dp::Integer)
-        buffer = Array{UInt8}(100 + dp)
-        ccall((:snprintf, :libc), Int, (Ptr{UInt8}, Csize_t, Cstring, Cdouble), buffer, length(buffer), "%.$(dp)f", val)
-        unsafe_string(pointer(buffer))
-    end
+    @eval @sprintf($("%.$(dp)f"), $val)
 end
 
 # FixedDecimal methods which perform an alternative method of trunc, floor, and ceil which
@@ -30,9 +17,7 @@ end
 function integer_alt{T<:Integer}(::Type{T}, dp::Integer, val::AbstractFloat)
     # Note: Use a precision larger than the value can represent so that `sprintf` doesn't
     # perform any rounding.
-    # TODO: Ideally we could be using just be using `@sprintf("%.325f", val)` once this
-    # issue is fixed: https://github.com/JuliaLang/julia/issues/22137
-    str = float_string(val, 325)  # 325 digits is large enough for `nextfloat(0.0)`
+    str = float_string(val)
     sign = T(first(str) == '-' ? -1 : 1)
     decimal = findfirst(str, '.')
     int_start = sign < 0 ? 2 : 1

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,58 @@
+# Format a floating-point number as a string with a specific precision. Similar to
+# `@sprintf("%.$(dp)f", val)`.
+
+if VERSION < v"0.6-"
+    function float_string(val::AbstractFloat, dp::Integer)
+        # On Julia 0.5 positive 0.0 can have extra bits. No other integer floating-point
+        # seems to have this problem.
+        isequal(val, 0.0) && return rpad("0.", dp, '0')
+        format = "%.$(dp)f"
+        @eval @sprintf($("%.$(dp)f"), nextfloat(0.0))
+        @eval begin
+            let buffer = Array{UInt8}(100 + $dp)
+                ccall((:snprintf, :libc), Int, (Ptr{UInt8}, Csize_t, Cstring, Cdouble), buffer, length(buffer), $format, $val)
+                unsafe_string(pointer(buffer))
+            end
+        end
+    end
+else
+    function float_string(val::AbstractFloat, dp::Integer)
+        buffer = Array{UInt8}(100 + dp)
+        ccall((:snprintf, :libc), Int, (Ptr{UInt8}, Csize_t, Cstring, Cdouble), buffer, length(buffer), "%.$(dp)f", val)
+        unsafe_string(pointer(buffer))
+    end
+end
+
+# FixedDecimal methods which perform an alternative method of trunc, floor, and ceil which
+# primarily use the string representation of the floating-point. These `*_alt` methods exist
+# to ensure the accuracy of the packages mathematical methods for trunc, floor, and ceil.
+
+function integer_alt{T<:Integer}(::Type{T}, dp::Integer, val::AbstractFloat)
+    # Note: Use a precision larger than the value can represent so that `sprintf` doesn't
+    # perform any rounding.
+    # TODO: Ideally we could be using just be using `@sprintf("%.325f", val)` once this
+    # issue is fixed: https://github.com/JuliaLang/julia/issues/22137
+    str = float_string(val, 325)  # 325 digits is large enough for `nextfloat(0.0)`
+    sign = T(first(str) == '-' ? -1 : 1)
+    decimal = findfirst(str, '.')
+    int_start = sign < 0 ? 2 : 1
+    int_end = decimal + dp
+    v = parse(T, str[int_start:(decimal - 1)] * str[(decimal + 1):int_end])
+    r = T(any(d -> d != '0', str[(int_end + 1):end]))  # Remaining digits
+    return (sign, v, r)
+end
+
+function trunc_alt{T<:Integer,f}(::Type{FD{T,f}}, val::AbstractFloat)
+    s, v, r = integer_alt(T, f, val)
+    reinterpret(FD{T,f}, copysign(v, s))
+end
+
+function floor_alt{T<:Integer,f}(::Type{FD{T,f}}, val::AbstractFloat)
+    s, v, r = integer_alt(T, f, val)
+    reinterpret(FD{T,f}, copysign(v + (s < 0 ? r : zero(T)), s))
+end
+
+function ceil_alt{T<:Integer,f}(::Type{FD{T,f}}, val::AbstractFloat)
+    s, v, r = integer_alt(T, f, val)
+    reinterpret(FD{T,f}, copysign(v + (s > 0 ? r : zero(T)), s))
+end


### PR DESCRIPTION
Fix #10.

There are two problems fixed here:

- change truncmul and friends to take a type as first argument. this can be the integer type, avoiding a floating point precision loss with `+`.
- if 10^n is not exactly representable as a float, promote to a sufficiently sized BigFloat while performing the computation

The existing tests have been bumped from 12 to 18, and I added a new test that goes to 200 with BigInt.