### PR TITLE
Use only bits types for CONTAINER_TYPES

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ const FD4 = FixedDecimal{Int, 4}
 const WFD2 = FixedDecimal{Int128, 2}
 const WFD4 = FixedDecimal{Int128, 4}
 
-const CONTAINER_TYPES = [subtypes(Signed); subtypes(Unsigned)]
+const CONTAINER_TYPES = Base.BitInteger_types  # Integer concrete subtypes which are bits
 
 # these arrays should be kept sorted manually
 const keyvalues = Dict(


### PR DESCRIPTION
A change introduced in Julia 0.7 made BigInt a subtype of Signed (JuliaLang/julia#23473). The change resulted in the code including BigInt in the CONTAINER_TYPES which resulted in an exceptions since BigInt is not a bits type.

Note that the JuliaLang/julia#23473 also introduced [a bug](https://github.com/JuliaLang/julia/issues/24298) which is causing the tests to fail.