### PR TITLE
Fix `var` and `std` when using 0 or 1-element array

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -30,7 +30,7 @@ export FixedDecimal, RoundThrows
 using Compat
 
 import Base: reinterpret, zero, one, abs, sign, ==, <, <=, +, -, /, *, div, rem, divrem,
-             fld, mod, fldmod, fld1, mod1, fldmod1, isinteger, typemin, typemax,
+             fld, mod, fldmod, fld1, mod1, fldmod1, var, isinteger, typemin, typemax,
              realmin, realmax, print, show, string, convert, parse, promote_rule, min, max,
              trunc, round, floor, ceil, eps, float, widemul
 
@@ -176,6 +176,15 @@ end
 function /(x::FD{T, f}, y::Integer) where {T, f}
     quotient, remainder = fldmod(x.i, y)
     reinterpret(FD{T, f}, T(_round_to_even(quotient, remainder, y)))
+end
+
+# Use floating-point when calculating variance to avoid divide by zero errors
+function var(A::AbstractArray{<:FixedDecimal}; corrected::Bool=true, mean=nothing)
+    var(convert.(AbstractFloat, A); corrected=corrected, mean=mean)
+end
+
+function var(A::AbstractArray{<:FixedDecimal}, region; corrected::Bool=true, mean=nothing)
+    var(convert.(AbstractFloat, A), region; corrected=corrected, mean=mean)
 end
 
 # integerification

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -494,6 +494,16 @@ end
     end
 end
 
+@testset "var" begin
+    @test isequal(var(FD2[]), NaN)
+    @test isequal(var(FD2[1]), NaN)
+    @test isequal(var(FD2[1, 2]), 0.5)
+
+    @test isequal(var(FD2[], 1), [NaN])
+    @test isequal(var(FD2[1], 1), [NaN])
+    @test isequal(var(FD2[1, 2], 1), [0.5])
+end
+
 @testset "abs, sign" begin
     @testset for T in [FD2, WFD4]
         for x in keyvalues[T]


### PR DESCRIPTION
Makes the `var` and `std` calculations always work.

Before PR
```julia
julia> using FixedPointDecimals

julia> std([FixedDecimal{Int,1}(384.0)])
ERROR: DivideError: integer division error
```

After PR
```julia
julia> using FixedPointDecimals

julia> std([FixedDecimal{Int,1}(384.0)])
NaN
```