### PR TITLE
Support Julia 0.6 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.6
   - 0.7
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7-beta2
+julia 0.6
 Compat 0.64.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+  - julia_version: 0.6
   - julia_version: 0.7
   - julia_version: latest
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -27,6 +27,8 @@ module FixedPointDecimals
 
 export FixedDecimal, RoundThrows
 
+using Compat: lastindex, something
+
 import Base: reinterpret, zero, one, abs, sign, ==, <, <=, +, -, /, *, div, rem, divrem,
              fld, mod, fldmod, fld1, mod1, fldmod1, isinteger, typemin, typemax,
              realmin, realmax, print, show, string, convert, parse, promote_rule, min, max,
@@ -207,7 +209,14 @@ as a floating point number.
 This is equivalent to counting the number of bits needed to represent the
 integer, excluding any trailing zeros.
 """
-required_precision(n::Integer) = ndigits(n, base=2) - trailing_zeros(n)
+required_precision(::Integer)
+
+# https://github.com/JuliaLang/julia/pull/27908
+if VERSION < v"0.7.0-beta.183"
+    required_precision(n::Integer) = ndigits(n, 2) - trailing_zeros(n)
+else
+    required_precision(n::Integer) = ndigits(n, base=2) - trailing_zeros(n)
+end
 
 """
     _apply_exact_float(f, T, x::Real, i::Integer)


### PR DESCRIPTION
Since it's pretty easy to keep supporting at this time why not keep supporting 0.6?