### PR TITLE
Improve constructor performance

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -460,7 +460,6 @@ The highest value of `x` which does not result in an overflow when evaluating `T
 types of `T` that do not overflow -1 will be returned.
 """
 function max_exp10(::Type{T}) where {T <: Integer}
-    applicable(typemax, T) || return -1
     W = widen(T)
     type_max = W(typemax(T))
 
@@ -474,6 +473,13 @@ function max_exp10(::Type{T}) where {T <: Integer}
     end
 
     exponent - 1
+end
+
+max_exp10(::Type{BigInt}) = -1
+
+# Pre-compute max_exp10 for the standard Integer types
+for T in Base.BitInteger_types
+    @eval max_exp10(::Type{$T}) = $(max_exp10(T))
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,20 @@ end
         x = FixedPointDecimals.max_exp10(T)
         @test T(10)^x == widen(T(10))^x
     end
+
+    @testset "custom integer types" begin
+        @eval begin
+            primitive type Int24 <: Integer 24 end
+            Base.typemax(::Type{Int24}) = 2^24
+            Base.widen(::Type{Int24}) = Int32
+        end
+
+        @test FixedPointDecimals.max_exp10(Int24) == 7
+
+        # Note: we're just pretending that this is unbounded
+        @eval primitive type IntUnbounded <: Integer 256 end
+        @test_throws MethodError FixedPointDecimals.max_exp10(IntUnbounded)
+    end
 end
 
 # ensure that the coefficient multiplied by the highest and lowest representable values of


### PR DESCRIPTION
Performance tested on Julia 1.0. 

Before:
```julia
julia> for i in 1:8
          @btime FixedDecimal{Int,$i}.(1:100)
       end
  8.986 μs (3 allocations: 960 bytes)
  9.034 μs (3 allocations: 960 bytes)
  10.391 μs (3 allocations: 960 bytes)
  9.667 μs (3 allocations: 960 bytes)
  10.601 μs (3 allocations: 960 bytes)
  10.630 μs (3 allocations: 960 bytes)
  10.768 μs (3 allocations: 960 bytes)
  9.423 μs (3 allocations: 960 bytes)
```
After (without pre-computing `max_exp10`):
```julia
julia> for i in 1:8
          @btime FixedDecimal{Int,$i}.(1:100)
       end
  531.746 ns (3 allocations: 960 bytes)
  569.186 ns (3 allocations: 960 bytes)
  1.888 μs (3 allocations: 960 bytes)
  706.234 ns (3 allocations: 960 bytes)
  1.934 μs (3 allocations: 960 bytes)
  2.056 μs (3 allocations: 960 bytes)
  2.153 μs (3 allocations: 960 bytes)
  700.782 ns (3 allocations: 960 bytes)
```
After (with pre-computing `max_exp10`):
```julia
julia> for i in 1:8
          @btime FixedDecimal{Int,$i}.(1:100)
       end
  390.299 ns (3 allocations: 960 bytes)
  426.136 ns (3 allocations: 960 bytes)
  1.875 μs (3 allocations: 960 bytes)
  541.351 ns (3 allocations: 960 bytes)
  1.961 μs (3 allocations: 960 bytes)
  1.966 μs (3 allocations: 960 bytes)
  2.189 μs (3 allocations: 960 bytes)
  533.450 ns (3 allocations: 960 bytes)
```
One caveat is that custom `Integer` types that don't support `typemax` will either need to implement `max_exp10(::Type{MyInt}) = -1` or they will fail when calling the fallback `max_exp10` method.