### PR TITLE
Remove `applicable` and it all const-folds away...

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -459,8 +459,7 @@ end
 The highest value of `x` which does not result in an overflow when evaluating `T(10)^x`. For
 types of `T` that do not overflow -1 will be returned.
 """
-@generated function max_exp10(::Type{T}) where {T <: Integer}
-    applicable(typemax, T) || return :(return -1)
+function max_exp10(::Type{T}) where {T <: BitInteger}
     W = widen(T)
     type_max = W(typemax(T))
 
@@ -473,7 +472,7 @@ types of `T` that do not overflow -1 will be returned.
         exponent += 1
     end
 
-    return :(return $(exponent-1))
+    exponent - 1
 end
 
 """

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -459,8 +459,8 @@ end
 The highest value of `x` which does not result in an overflow when evaluating `T(10)^x`. For
 types of `T` that do not overflow -1 will be returned.
 """
-function max_exp10(::Type{T}) where {T <: Integer}
-    applicable(typemax, T) || return -1
+@generated function max_exp10(::Type{T}) where {T <: Integer}
+    applicable(typemax, T) || return :(return -1)
     W = widen(T)
     type_max = W(typemax(T))
 
@@ -473,7 +473,7 @@ function max_exp10(::Type{T}) where {T <: Integer}
         exponent += 1
     end
 
-    exponent - 1
+    return :(return $(exponent-1))
 end
 
 """


### PR DESCRIPTION
This was my first attempt at fixing the constructor performance. If we simply limit the function to only work for known bitstype integer types (UInt8-UInt64, Int8-Int64), then we don't need that runtime check, since we know it'll work.

That said, this is of course terribly in-extensible, since we're manually restricting this method to only work for the provided types.

