### PR TITLE
Fix constructor performance by `@eval`ing a definition of `max_exp10` for all known types

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -459,8 +459,8 @@ end
 The highest value of `x` which does not result in an overflow when evaluating `T(10)^x`. For
 types of `T` that do not overflow -1 will be returned.
 """
-function max_exp10(::Type{T}) where {T <: Integer}
-    applicable(typemax, T) || return -1
+@generated function max_exp10(::Type{T}) where {T <: Integer}
+    applicable(typemax, T) || return :(return -1)
     W = widen(T)
     type_max = W(typemax(T))
 
@@ -473,7 +473,7 @@ function max_exp10(::Type{T}) where {T <: Integer}
         exponent += 1
     end
 
-    exponent - 1
+    return :(return $(exponent-1))
 end
 
 """


### PR DESCRIPTION
This was the first extensible solution suggested in the thread.

It removes the runtime overhead of the constructor by evaluating the `max_exp10` function body ahead of time _at global scope_ (ie during module initialization) for all known valid Integer types.

Users can extend this for new Integer types by evaluating a new definition for their type:
```julia
    @eval max_exp10(::Type{MyInt}) = $(calculate_max_exp10(MyInt))
```

I chose to leave the type-error for custom types (until they do the above), rather than falling back to a default which performs the check at runtime, but you could do that too.

This solution is more or less the same as https://github.com/JuliaMath/FixedPointDecimals.jl/pull/30.