### PR TITLE
Fix constructor performance via Holy Traits.

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -459,8 +459,8 @@ end
 The highest value of `x` which does not result in an overflow when evaluating `T(10)^x`. For
 types of `T` that do not overflow -1 will be returned.
 """
-function max_exp10(::Type{T}) where {T <: Integer}
-    applicable(typemax, T) || return -1
+@generated function max_exp10(::Type{T}) where {T <: Integer}
+    applicable(typemax, T) || return :(return -1)
     W = widen(T)
     type_max = W(typemax(T))
 
@@ -473,7 +473,7 @@ function max_exp10(::Type{T}) where {T <: Integer}
         exponent += 1
     end
 
-    exponent - 1
+    return :(return $(exponent-1))
 end
 
 """


### PR DESCRIPTION
This is the most generic solution: it allows users to extend FixedPointDecimals simply by defining `is_bit_integer_type(::MyType) = BitIntegerType() ` for their type.

I defined it by default for all the types in `BitInteger`, which is defined at the [top of the file](https://github.com/JuliaMath/FixedPointDecimals.jl/blob/8bf579f0872a989971560314fe6e013f22a5ae4c/src/FixedPointDecimals.jl#L39), but could've also used `Base. BitInteger`.

This fixes the performance by removing the call to `applicable`, which prevents const-folding.