### PR TITLE
Fix constructor performance by swapping runtime-evaluated `applicable` with static `isbitstype`

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -27,7 +27,7 @@ module FixedPointDecimals
 
 export FixedDecimal, RoundThrows
 
-using Compat: lastindex, something
+using Compat: lastindex, something, isbitstype
 
 import Compat: floatmin, floatmax
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -459,8 +459,9 @@ end
 The highest value of `x` which does not result in an overflow when evaluating `T(10)^x`. For
 types of `T` that do not overflow -1 will be returned.
 """
-@generated function max_exp10(::Type{T}) where {T <: Integer}
-    applicable(typemax, T) || return :(return -1)
+function max_exp10(::Type{T}) where {T <: Integer}
+    # max_exp10 only makes sense for types with a fixed size in bytes.
+    isbitstype(T) || return -1
     W = widen(T)
     type_max = W(typemax(T))
 
@@ -473,7 +474,7 @@ types of `T` that do not overflow -1 will be returned.
         exponent += 1
     end
 
-    return :(return $(exponent-1))
+    exponent - 1
 end
 
 """

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -459,8 +459,8 @@ end
 The highest value of `x` which does not result in an overflow when evaluating `T(10)^x`. For
 types of `T` that do not overflow -1 will be returned.
 """
-function max_exp10(::Type{T}) where {T <: Integer}
-    applicable(typemax, T) || return -1
+@generated function max_exp10(::Type{T}) where {T <: Integer}
+    applicable(typemax, T) || return :(return -1)
     W = widen(T)
     type_max = W(typemax(T))
 
@@ -473,7 +473,7 @@ function max_exp10(::Type{T}) where {T <: Integer}
         exponent += 1
     end
 
-    exponent - 1
+    return :(return $(exponent-1))
 end
 
 """


### PR DESCRIPTION
Okay!

I actually think this is probably the best fix, just because it's the simplest. Basically, the whole problem stemmed from the call to `applicable`, which prevents const-folding since its value depends on global state. The return value of `applicable` can change if you define new methods, so it has to check every time it would be called at runtime.

I just switched it out for `isbitstype`, which I think is a good enough proxy, is closer to what we actually meant with this check anyway, and of course depends only on the type definition, so its result is static. This allows the entire method to be compiled away.