### PR TITLE
Fix construction with same type performing convert

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -99,6 +99,9 @@ struct FixedDecimal{T <: Integer, f} <: Real
             _throw_storage_error(f, T, n)
         end
     end
+
+    # Copy constructor -- prevents unneeded work to convert between the same types
+    FixedDecimal{T,f}(x::FixedDecimal{T,f}) where {T<:Integer,f} = new{T,f}(x.i)
 end
 
 @noinline function _throw_storage_error(f, T, n)


### PR DESCRIPTION
Before this PR, constructing a new FD with the same type called `convert`. That happened due to this line, since `FD<: Real`:
https://github.com/JuliaMath/FixedPointDecimals.jl/blob/cc6aed31ec84e8e6e0f428f9a36d34652b48a9c2/src/FixedPointDecimals.jl#L113

```
julia> f =  FixedPointDecimals.FixedDecimal{Int8, 2}(1)
>> FixedDecimal{Int8,2}(1.00)

julia> @which typeof(f)(f)
>> (::Type{T})(x::Real) where T<:FixedDecimal in FixedPointDecimals at /Users/daly/.julia/dev/FixedPointDecimals/src/FixedPointDecimals.jl:113
```

This PR adds a "copy constructor" to avoid that. I'm not really sure what the idiomatic name for it would be in julia, "copy constructor" of course references the name of the same concept in C++. :)


Perhaps a separate issue is that for some reason `convert` is super expensive when `T=Int128`, which is how I stumbled across this problem. But either way, i think this PR could make sense.