### PR TITLE
Performance fix: avoid unnecessary `convert` on setindex!、copy when type is same.

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -274,6 +274,8 @@ function round(::Type{FD{T, f}}, x::Rational, ::RoundingMode{:Nearest}=RoundNear
 end
 
 # conversions and promotions
+convert(::Type{FD{T, f}}, x::FD{T, f}) where {T, f} = x  # Converting an FD to itself is a no-op
+
 function convert(::Type{FD{T, f}}, x::Integer) where {T, f}
     reinterpret(FD{T, f}, T(widemul(x, coefficient(FD{T, f}))))
 end

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -99,9 +99,6 @@ struct FixedDecimal{T <: Integer, f} <: Real
             _throw_storage_error(f, T, n)
         end
     end
-
-    # Copy constructor -- prevents unneeded work to convert between the same types
-    FixedDecimal{T,f}(x::FixedDecimal{T,f}) where {T<:Integer,f} = new{T,f}(x.i)
 end
 
 @noinline function _throw_storage_error(f, T, n)


### PR DESCRIPTION
Add `convert(::Type{T}, x::T) where {T<:FD} = x`

This fixes unnecessary copies on `setindex!`, etc.

Fixes the allocations issue for `identity` from this table, by preventing the widening to `BigInt`:
https://github.com/JuliaMath/FixedPointDecimals.jl/issues/37

This is the same situation as this issue:
JuliaLang/julia#17559