### PR TITLE
Make FD÷FD return an FD.

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -305,6 +305,8 @@ for remfn in [:rem, :mod, :mod1, :min, :max]
     @eval $remfn(x::T, y::T) where {T <: FD} = reinterpret(T, $remfn(x.i, y.i))
 end
 for divfn in [:div, :fld, :fld1]
+    # div(x.i, y.i) eliminates the scaling coefficient, so we call the FD constructor.
+    # We don't need any widening logic, since we won't be multiplying by the coefficient.
     @eval $divfn(x::T, y::T) where {T <: FD} = T($divfn(x.i, y.i))
 end
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -305,7 +305,7 @@ for remfn in [:rem, :mod, :mod1, :min, :max]
     @eval $remfn(x::T, y::T) where {T <: FD} = reinterpret(T, $remfn(x.i, y.i))
 end
 for divfn in [:div, :fld, :fld1]
-    @eval $divfn(x::T, y::T) where {T <: FD} = $divfn(x.i, y.i)
+    @eval $divfn(x::T, y::T) where {T <: FD} = T($divfn(x.i, y.i))
 end
 
 convert(::Type{AbstractFloat}, x::FD) = convert(floattype(typeof(x)), x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -512,19 +512,19 @@ end
 @testset "truncating div" begin
     @testset "div by 1" begin
         @testset for x in keyvalues[FD2]
-            @test x ÷ one(x) == trunc(x)
+            @test x ÷ one(x) === trunc(x)
 
             # signed integers using two's complement have one additional negative value
-            if x < 0 && trunc(x) == typemin(x)
+            if x < 0 && trunc(x) === typemin(x)
                 @test_throws InexactError x ÷ -one(x)
             else
-                @test x ÷ -one(x) == -trunc(x)
+                @test x ÷ -one(x) === -trunc(x)
             end
         end
     end
     @testset "div by 2" begin
         @testset for x in keyvalues[FD2]
-            @test x ÷ 2one(x) == x ÷ 2 == x.i ÷ FD2(2).i
+            @test x ÷ 2one(x) === x ÷ 2 === FD2(x.i ÷ FD2(2).i)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -509,6 +509,26 @@ end
     end
 end
 
+@testset "truncating div" begin
+    @testset "div by 1" begin
+        @testset for x in keyvalues[FD2]
+            @test x ÷ one(x) == trunc(x)
+
+            # signed integers using two's complement have one additional negative value
+            if x < 0 && trunc(x) == typemin(x)
+                @test_throws InexactError x ÷ -one(x)
+            else
+                @test x ÷ -one(x) == -trunc(x)
+            end
+        end
+    end
+    @testset "div by 2" begin
+        @testset for x in keyvalues[FD2]
+            @test x ÷ 2one(x) == x ÷ 2 == x.i ÷ FD2(2).i
+        end
+    end
+end
+
 @testset "abs, sign" begin
     @testset for T in [FD2, WFD4]
         for x in keyvalues[T]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -527,6 +527,16 @@ end
             @test x ÷ 2one(x) === x ÷ 2 === FD2(x.i ÷ FD2(2).i)
         end
     end
+    @testset "return types" begin
+        @test div(2one(FD2), 3) isa FD2
+        @test one(FD2) ÷ one(FD2) isa FD2
+
+        # Promotion to bigger type
+        @test one(FD4) ÷ one(FD2) isa FD4
+        @test one(FD2) ÷ one(FD4) isa FD4
+
+        @test one(FD{Int32, 2}) ÷ one(FD{Int64, 6}) isa FD{Int64, 6}
+    end
 end
 
 @testset "abs, sign" begin


### PR DESCRIPTION
Before this, `FD{T,f} ÷ FD{T,f}` returned `T`, now it returns `FD{T,f}`.

Same for `div`, `fld`, and `fld`.

--------------

Here's an example of the old behavior. Addition and division for two `FixedDecimals` returns a `FixedDecimal`, but integer division (`div`) was returning the raw storage type `T` instead of wrapping it in a FixedDecimal.

```julia
julia> FixedDecimal{Int32, 2}(2)+FixedDecimal{Int32, 2}(1)
>> FixedDecimal{Int32,2}(3.00)

julia> FixedDecimal{Int32,2}(4.00) / FixedDecimal{Int32,2}(2.00)
>> FixedDecimal{Int32,2}(2.00)

julia> FixedDecimal{Int32, 2}(2)÷FixedDecimal{Int32, 2}(1)
>> 2
```