### PR TITLE
Prevent allocations for FD{Int128} by freezing max_exp10(Int128)

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -484,6 +484,7 @@ function max_exp10(::Type{T}) where {T <: Integer}
 end
 
 max_exp10(::Type{BigInt}) = -1
+@eval max_exp10(::Type{Int128}) = $(max_exp10(Int128))  # Freeze this, since it's not getting Const folded.
 
 """
     coefficient(::Type{FD{T, f}}) -> T

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -484,7 +484,9 @@ function max_exp10(::Type{T}) where {T <: Integer}
 end
 
 max_exp10(::Type{BigInt}) = -1
-@eval max_exp10(::Type{Int128}) = $(max_exp10(Int128))  # Freeze this, since it's not getting Const folded.
+# Freeze the evaluation for Int128, since max_exp10(Int128) is too compilicated to get
+# optimized away by the compiler during const-folding.
+@eval max_exp10(::Type{Int128}) = $(max_exp10(Int128))
 
 """
     coefficient(::Type{FD{T, f}}) -> T


### PR DESCRIPTION
This is a follow-up to https://github.com/JuliaMath/FixedPointDecimals.jl/pull. It seems that removing `applicable` wasn't sufficient for the case where `T=Int128`.

Before this PR, `reinterpret(FD{Int128,f}, x)` allocates because:
 1. `max_exp10(Int128)` widens the `Int128` to a `BigInt`, which causes allocations.
 2. The result of `max_exp10(Int128)` isn't getting const-folded away, so the above widen operation occurs every time it's called at runtime.

```julia
julia> @btime reinterpret(FixedPointDecimals.FD{Int64,2}, 200)
  1.704 ns (0 allocations: 0 bytes)
>> FixedDecimal{Int64,2}(2.00)

julia> @btime reinterpret(FixedPointDecimals.FD{Int128,2}, 200)
  5.090 μs (152 allocations: 2.61 KiB)
>> FixedDecimal{Int128,2}(2.00)
```


I'm not entirely sure _why_ `max_exp10(Int128)` isn't const-folding, but here's my _guess_:
Because `max_exp10(::Type{Int128})` ends up more complicated (because it allocates, etc), I think it ends up not being inlined, where for other int types it _is_ inlined. And so then, because it's not inlined, LLVM isn't able to determine that its input is a static constant, so it doesn't know it can eliminate the function entirely.

Here we can see it not being inlined:
```julia
julia> @code_typed reinterpret(FixedPointDecimals.FD{Int64,2}, 200)
>> CodeInfo(
   1 ──       nothing::Nothing                                                                                                                                  │
93 2 ┄─ %2  = φ (#1 => 1, #3 => %8)::Int128                                                                                                                     │╻  max_exp10
   │    %3  = φ (#1 => 0, #3 => %9)::Int64                                                                                                                      ││
   │    %4  = π (9223372036854775807, Int128)                                                                                                                   ││
   │    %5  = (Base.slt_int)(%2, %4)::Bool                                                                                                                      ││╻  >
   └───       goto #4 if not %5                                                                                                                                 ││
   3 ── %7  = π (10, Int128)                                                                                                                                    ││
   │    %8  = (Base.mul_int)(%2, %7)::Int128                                                                                                                    ││╻  *
   │    %9  = (Base.add_int)(%3, 1)::Int64                                                                                                                      ││╻  +
   └───       goto #2                                                                                                                                           ││
   4 ── %11 = (Base.sub_int)(%3, 1)::Int64                                                                                                                      ││╻  -
   └───       goto #5                                                                                                                                           ││
94 5 ── %13 = (Base.slt_int)(%11, 0)::Bool                                                                                                                      │╻  <
   └───       goto #7 if not %13                                                                                                                                │
   6 ──       goto #8                                                                                                                                           │
   7 ── %16 = $(Expr(:static_parameter, 2))::Const(2, false)                                                                                                    │
   └─── %17 = (Base.sle_int)(%16, %11)::Bool                                                                                                                    │╻  <=
   8 ┄─ %18 = φ (#6 => %13, #7 => %17)::Bool                                                                                                                    │
   └───       goto #10 if not %18                                                                                                                               │
95 9 ── %20 = %new(FixedDecimal{Int64,2}, i)::FixedDecimal{Int64,2}                                                                                             │
   └───       return %20                                                                                                                                        │
99 10 ─       invoke FixedPointDecimals._throw_storage_error($(Expr(:static_parameter, 2))::Int64, $(Expr(:static_parameter, 1))::Type, %11::Int64)::Union{}    │
   └───       $(Expr(:unreachable))::Union{}                                                                                                                    │
) => FixedDecimal{Int64,2}

julia> @code_typed reinterpret(FixedPointDecimals.FD{Int128,2}, 200)
>> CodeInfo(
93 1 ─ %1  = invoke FixedPointDecimals.max_exp10($(Expr(:static_parameter, 1))::Type{Int128})::Int64                                                                   │
94 │   %2  = (Base.slt_int)(%1, 0)::Bool                                                                                                                               │╻ <
   └──       goto #3 if not %2                                                                                                                                         │
   2 ─       goto #4                                                                                                                                                   │
   3 ─ %5  = $(Expr(:static_parameter, 2))::Const(2, false)                                                                                                            │
   └── %6  = (Base.sle_int)(%5, %1)::Bool                                                                                                                              │╻ <=
   4 ┄ %7  = φ (#2 => %2, #3 => %6)::Bool                                                                                                                              │
   └──       goto #6 if not %7                                                                                                                                         │
95 5 ─ %9  = (Base.sext_int)(Int128, i)::Int128                                                                                                                        │╻ rem
   │   %10 = %new(FixedDecimal{Int128,2}, %9)::FixedDecimal{Int128,2}                                                                                                  │
   └──       return %10                                                                                                                                                │
99 6 ─       invoke FixedPointDecimals._throw_storage_error($(Expr(:static_parameter, 2))::Int64, $(Expr(:static_parameter, 1))::Type, %1::Int64)::Union{}             │
   └──       $(Expr(:unreachable))::Union{}                                                                                                                            │
) => FixedDecimal{Int128,2}
```

And so then LLVM is able to const fold everything away, even though julia wasn't able to:
```juila
julia> @code_native reinterpret(FixedPointDecimals.FD{Int64,2}, 200)
        .section        __TEXT,__text,regular,pure_instructions
; Function reinterpret {
; Location: FixedPointDecimals.jl:93
        decl    %eax
        movl    %esi, %eax
        retl
        nopw    %cs:(%eax,%eax)
;}
```
(I'm not including the `@code_native` for Int128, because it's very long.)
