### PR TITLE
Improve performance for FD multiplication: allow LLVM to optimize away the division by a constant.

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -154,12 +154,18 @@ function _round_to_even(quotient::T, remainder::T, divisor::T) where {T <: Integ
 end
 _round_to_even(q, r, d) = _round_to_even(promote(q, r, d)...)
 
+# In many of our calls to fldmod, `y` is a constant (the coefficient, 10^f). However, since
+# `fldmod` is sometimes not being inlined, that constant information is not available to the
+# optimizer. We need an inlined version of fldmod so that the compiler can replace expensive
+# divide-by-power-of-ten instructions with the cheaper multiply-by-inverse-coefficient.
+@inline fldmodinline(x,y) = (fld(x,y), mod(x,y))
+
 # multiplication rounds to nearest even representation
 # TODO: can we use floating point to speed this up? after we build a
 # correctness test suite.
 function *(x::FD{T, f}, y::FD{T, f}) where {T, f}
     powt = coefficient(FD{T, f})
-    quotient, remainder = fldmod(widemul(x.i, y.i), powt)
+    quotient, remainder = fldmodinline(widemul(x.i, y.i), powt)
     reinterpret(FD{T, f}, _round_to_even(quotient, remainder, powt))
 end
 
@@ -195,12 +201,12 @@ floor(x::FD{T, f}) where {T, f} = FD{T, f}(fld(x.i, coefficient(FD{T, f})))
 # TODO: round with number of digits; should be easy
 function round(x::FD{T, f}, ::RoundingMode{:Nearest}=RoundNearest) where {T, f}
     powt = coefficient(FD{T, f})
-    quotient, remainder = fldmod(x.i, powt)
+    quotient, remainder = fldmodinline(x.i, powt)
     FD{T, f}(_round_to_even(quotient, remainder, powt))
 end
 function ceil(x::FD{T, f}) where {T, f}
     powt = coefficient(FD{T, f})
-    quotient, remainder = fldmod(x.i, powt)
+    quotient, remainder = fldmodinline(x.i, powt)
     if remainder > 0
         FD{T, f}(quotient + one(quotient))
     else


### PR DESCRIPTION
A large part of the runtime cost of `*(x::FD, y::FD)` comes from dividing the result of `widemul(x,y)` by the coefficient (`10^f`).

However, that coefficient is a known, compile-time static constant, and so we should be able to replace that expensive division-by-a-constant with cheaper alternatives. LLVM can normally do this optimization, but in this case, it's prevented from doing so in our code because `fldmod` is acting as a function barrier. If `fldmod` isn't inlined, it's compiled without any knowledge that one of its arguments is a compile-time constant.

This PR simply changes our multiplication (and round and ceil) to call a version of fldmod marked `inline`, which allows LLVM to optimize the division-by-constant into a cheaper operation.

Before this PR, the call to `fldmod` takes around 80% of the time of `*` according to this profile:
<img width="535" alt="screen shot 2018-12-06 at 1 14 14 pm" src="https://user-images.githubusercontent.com/1582097/49603416-34521400-f959-11e8-81f4-1deb317f80ce.png">
 (`(2936+3+8275)/(13693+399) == 79.6%`)

The above is generated from:
```julia
julia> using Profile, StatProfilerHTML, FixedPointDecimals
       function foo()
         out = FixedPointDecimals.FixedDecimal{Int32,2}(1.02);
         Profile.clear()
         @profile for i in 1:1_000_000_000; out = out * out; end
       end
       foo(); statprofilehtml()
```

After this PR, that number drops to 64%, which doesn't seem like that much, but in my overall benchmark suite, this change consistently improves the time for `*(::FD{Int32,2}, ::FD{Int32,2})` by ~70%! So I might be missing something in my profiling.

Here are my benchmark results after this change (and the `@eval` for `maxexp10(Int128)` change, in https://github.com/JuliaMath/FixedPointDecimals.jl/pull/41):

  |   | Operation | Values |   |   |   |   |   |   |   |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
  |   | * |   | / |   | + |   | div |   | identity |  
Category | Type | time (ns) * | % improvement | time (ns) * | % improvement | time (ns) * | % improvement | time (ns) * | % improvement | time (ns) * | % improvement
Int | Int32 | 0.35 | 0% | 3.86 | -2% | 0.35 | 0% | 0.35 | 0% | 0.35 | 0%
  | Int64 | 0.35 | 0% | 3.93 | -4% | 0.35 | 0% | 0.35 | 0% | 0.35 | 0%
  | Int128 | 0.39 | 8% | 13.28 | -3% | 0.35 | 0% | 0.35 | 0% | 0.35 | 0%
Float | Float32 | 0.35 | 0% | 0.35 | 0% | 0.35 | 0% | 2.69 | 0% | 0.35 | 0%
  | Float64 | 0.35 | 0% | 0.35 | 0% | 0.35 | 0% | 2.69 | -4% | 0.35 | 0%
FixedDecimal | FD{ Int32,2} | 2.92 | 72% | 9.81 | -13% | 0.35 | 0% | 0.35 | 0% | 0.35 | 0%
  | FD{ Int64,2} | 16.61 | 9% | 21.94 | -4% | 0.35 | 0% | 0.35 | 88% | 0.35 | 0%
  | FD{Int128,2} | 2123.24 | 82% | 1986.91 | 85% | 0.35 | 100% | 558.76 | 96% | 5.40 | 100%
Big | BigFloat | 71.08 | 0% | 146.58 | -5% | 49.14 | -16% | 188.99 | -23% | 0.35 | 0%
  | BigInt | 228.66 | -13% | 518.31 | -6% | 196.80 | -8% | 196.36 | 2% | 0.35 | 0%

`* note: The times in each column are truncated to a minimum of 0.345ns, which is the estimated time for a single clock cycle on my machine.`
Comparisons are relative to benchmarks run on `master`. Those results are here: https://github.com/JuliaMath/FixedPointDecimals.jl/issues/37#issuecomment-444932180

For the small numbers, it's fairly noisy (that 8% improvement in `*`, `Int128` is noise, for example) but for the larger numbers it seems fairly consistent between runs.

(Almost all of the improvements on the `FD{Int128,2}` line come from https://github.com/JuliaMath/FixedPointDecimals.jl/pull/41, since inlining `fldmod` doesn't seem to help any when you're doing `BigInt` math.)


