### PR TITLE
Update .travis.yml coverage lines for julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ julia:
   - nightly
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("FixedPointDecimals"); Pkg.test("FixedPointDecimals"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("FixedPointDecimals")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  - julia -e 'cd(Pkg.dir("FixedPointDecimals")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'


### PR DESCRIPTION
- Add `using Pkg` if `VERSION` >= 0.7.
- The default Travis scripts now keep the `cwd` inside the package, so we don't need the `cd()` line.


We can submit this instead of https://github.com/JuliaMath/FixedPointDecimals.jl/pull/29.