### PR TITLE
Optimize zero(FD{T,f}): implement via reinterpret not convert.

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -345,6 +345,7 @@ Base.@pure function promote_rule(::Type{FD{T, f}}, ::Type{FD{U, g}}) where {T, f
     FD{promote_type(T, U), max(f, g)}
 end
 
+# The default `Base.zero` calls `convert`, which is expensive, so we call reinterpret.
 Base.zero(::Type{FD{T, f}}) where {T, f} = reinterpret(FD{T,f}, zero(T))
 
 # comparison

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -345,8 +345,9 @@ Base.@pure function promote_rule(::Type{FD{T, f}}, ::Type{FD{U, g}}) where {T, f
     FD{promote_type(T, U), max(f, g)}
 end
 
-# The default `Base.zero` calls `convert`, which is expensive, so we call reinterpret.
+# The default `zero` and `one` call `convert`, which is expensive, so we call reinterpret.
 Base.zero(::Type{FD{T, f}}) where {T, f} = reinterpret(FD{T, f}, zero(T))
+Base.one(::Type{FD{T, f}}) where {T, f} = reinterpret(FD{T, f}, coefficient(FD{T, f}))
 
 # comparison
 ==(x::T, y::T) where {T <: FD} = x.i == y.i
@@ -508,7 +509,7 @@ max_exp10(::Type{BigInt}) = -1
 Compute `10^f` as an Integer without overflow. Note that overflow will not occur for any
 constructable `FD{T, f}`.
 """
-coefficient(::Type{FD{T, f}}) where {T, f} = T(10)^f
+Base.@pure coefficient(::Type{FD{T, f}}) where {T, f} = T(10)^f
 coefficient(fd::FD{T, f}) where {T, f} = coefficient(FD{T, f})
 value(fd::FD) = fd.i
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -346,7 +346,7 @@ Base.@pure function promote_rule(::Type{FD{T, f}}, ::Type{FD{U, g}}) where {T, f
 end
 
 # The default `Base.zero` calls `convert`, which is expensive, so we call reinterpret.
-Base.zero(::Type{FD{T, f}}) where {T, f} = reinterpret(FD{T,f}, zero(T))
+Base.zero(::Type{FD{T, f}}) where {T, f} = reinterpret(FD{T, f}, zero(T))
 
 # comparison
 ==(x::T, y::T) where {T <: FD} = x.i == y.i

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -503,6 +503,8 @@ max_exp10(::Type{BigInt}) = -1
 # optimized away by the compiler during const-folding.
 @eval max_exp10(::Type{Int128}) = $(max_exp10(Int128))
 
+# coefficient is marked pure. This is needed to ensure that the result is always available
+# at compile time, and can therefore be used when optimizing mathematical operations.
 """
     coefficient(::Type{FD{T, f}}) -> T
 
@@ -510,7 +512,7 @@ Compute `10^f` as an Integer without overflow. Note that overflow will not occur
 constructable `FD{T, f}`.
 """
 Base.@pure coefficient(::Type{FD{T, f}}) where {T, f} = T(10)^f
-coefficient(fd::FD{T, f}) where {T, f} = coefficient(FD{T, f})
+Base.@pure coefficient(fd::FD{T, f}) where {T, f} = coefficient(FD{T, f})
 value(fd::FD) = fd.i
 
 # for generic hashing


### PR DESCRIPTION
Before this PR, `zero(FD{Int,3})` is expensive, since it calls `convert()`, which multiplies `0` by coefficient, etc. This PR switches to use `reinterpret(FD{T,f}, zero(T))` instead.

I also noticed, though, that even after that change, `reinterpret()` is still not fully const-folding. 
```julia
julia> @code_typed zero(FixedPointDecimals.FixedDecimal{Int64,3})
>> CodeInfo(
263 1 ─ %1  = invoke Base.power_by_squaring(10::Int64, 3::Int64)::Int64                                │╻╷╷   convert
    │   %2  = (Core.sext_int)(Core.Int128, %1)::Int128                                                 ││╻╷╷╷  widemul
    │   %3  = (Base.mul_int)(0, %2)::Int128                                                            │││╻     *
    │   %4  = (Core.trunc_int)(Int64, %3)::Int64                                                       │││╻╷    toInt64
    │   %5  = (Core.sext_int)(Int128, %4)::Int128                                                      ││││┃     checked_trunc_sint
    │   %6  = (Core.eq_int)(%3, %5)::Bool                                                              │││││ 
    └──       goto #3 if not %6                                                                        │││││ 
    2 ─       goto #4                                                                                  │││││ 
    3 ─       invoke Core.throw_inexacterror(:trunc::Symbol, Int64::Any, %3::Int128)::Union{}          │││││ 
    └──       $(Expr(:unreachable))::Union{}                                                           │││││ 
    4 ┄       goto #5                                                                                  ││││  
    5 ─       goto #6                                                                                  │││   
    6 ─ %13 = %new(FixedDecimal{Int64,3}, %4)::FixedDecimal{Int64,3}                                   ││╻     reinterpret
    └──       goto #7                                                                                  ││    
    7 ─       return %13                                                                               │     
) => FixedDecimal{Int64,3}
```

Often, LLVM is still able to fold this away in simple constructions, but inside complex expressions it sometimes isn't:

Here it does fold away:
```julia
julia> @code_llvm zero(FixedPointDecimals.FixedDecimal{Int64,3})

; Function zero
; Location: /Users/nathan.daly/.julia/dev/FixedPointDecimals/src/FixedPointDecimals.jl:348
define { i64 } @julia_zero_37093(%jl_value_t addrspace(10)*) {
top:
  ret { i64 } zeroinitializer
}
```
But here it doesn't:
```juila
julia> foo() = (zero(Int), zero(Float32), zero(FixedPointDecimals.FixedDecimal{Int64,3}))

julia> @code_llvm foo()

; Function foo
; Location: none:1
define void @julia_foo_37090({ i64, float, { i64 } }* noalias nocapture sret) {
top:
  %.sroa.0.0..sroa_idx = getelementptr inbounds { i64, float, { i64 } }, { i64, float, { i64 } }* %0, i64 0, i32 0
  store i64 0, i64* %.sroa.0.0..sroa_idx, align 8
  %.sroa.2.0..sroa_idx1 = getelementptr inbounds { i64, float, { i64 } }, { i64, float, { i64 } }* %0, i64 0, i32 1
  store float 0.000000e+00, float* %.sroa.2.0..sroa_idx1, align 8
  %.sroa.3.sroa.1.0..sroa.3.0..sroa_raw_idx.sroa_idx3 = getelementptr inbounds { i64, float, { i64 } }, { i64, float, { i64 } }* %0, i64 0, i32 2, i32 0
  store i64 0, i64* %.sroa.3.sroa.1.0..sroa.3.0..sroa_raw_idx.sroa_idx3, align 8
  ret void
}
```

--------------

I fixed this by marking both `reinterpret` and `max_exp10` as `Base.@pure`.

After this change, Julia is able to do the const-folding itself:
```julia
julia> @code_typed foo()
>> CodeInfo(
1 1 ─     return (0, 0.0, 0.0)                                                                                                    │
) => Tuple{Int64,Float32,FixedDecimal{Int64,3}}
```
