### PR TITLE
Adds tests for Type Stability of FD functions.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -794,24 +794,24 @@ end
         frange = filter(f->f<=maxF, fs)
         # Unary operations
         @testset for f in frange
-            @test @inferred(zero(FD{T,f}(1))) == FD{T,f}(0)
-            @test @inferred(one(FD{T,f}(1))) == FD{T,f}(1)
-            @test @inferred(ceil(FD{T,f}(1))) == FD{T,f}(1)
-            @test @inferred(round(FD{T,f}(1))) == FD{T,f}(1)
-            @test @inferred(abs(FD{T,f}(1))) == FD{T,f}(1)
-            @test @inferred(FD{T,f}(1)^2) == FD{T,f}(1)
-            @test (@inferred(typemax(FD{T,f})); true)
+            @test @inferred(zero(FD{T,f}(1))) === FD{T,f}(0)
+            @test @inferred(one(FD{T,f}(1))) === FD{T,f}(1)
+            @test @inferred(ceil(FD{T,f}(1))) === FD{T,f}(1)
+            @test @inferred(round(FD{T,f}(1))) === FD{T,f}(1)
+            @test @inferred(abs(FD{T,f}(1))) === FD{T,f}(1)
+            @test @inferred(FD{T,f}(1)^2) === FD{T,f}(1)
+            @test @inferred(typemax(FD{T,f})) isa FD{T,f}
         end
         # Binary operations
         @testset for (f1,f2) in Iterators.product(frange, frange)
             fmax = max(f1,f2)
-            @test @inferred(FD{T,f1}(1) + FD{T,f2}(0)) == FD{T,fmax}(1)
-            @test @inferred(FD{T,f1}(1) - FD{T,f2}(0)) == FD{T,fmax}(1)
-            @test @inferred(FD{T,f1}(1) * FD{T,f2}(1)) == FD{T,fmax}(1)
-            @test @inferred(FD{T,f1}(1) / FD{T,f2}(1)) == FD{T,fmax}(1)
-            @test @inferred(FD{T,f1}(1) ÷ FD{T,f2}(1)) == FD{T,fmax}(1)
-            @test @inferred(max(FD{T,f1}(1), FD{T,f2}(0))) == FD{T,fmax}(1)
-            @test @inferred(min(FD{T,f1}(1), FD{T,f2}(0))) == FD{T,fmax}(0)
+            @test @inferred(FD{T,f1}(1) + FD{T,f2}(0)) === FD{T,fmax}(1)
+            @test @inferred(FD{T,f1}(1) - FD{T,f2}(0)) === FD{T,fmax}(1)
+            @test @inferred(FD{T,f1}(1) * FD{T,f2}(1)) === FD{T,fmax}(1)
+            @test @inferred(FD{T,f1}(1) / FD{T,f2}(1)) === FD{T,fmax}(1)
+            @test @inferred(FD{T,f1}(1) ÷ FD{T,f2}(1)) === FD{T,fmax}(1)
+            @test @inferred(max(FD{T,f1}(1), FD{T,f2}(0))) === FD{T,fmax}(1)
+            @test @inferred(min(FD{T,f1}(1), FD{T,f2}(0))) === FD{T,fmax}(0)
         end
     end
 end


### PR DESCRIPTION
Test that most of the API functions for FixedDecimals are type stable in
their return type, using the `@inferred` test macro.

Tests this for all built-in integer types, across many precisions.

(Adds around 10 seconds to test time.)


-----------

My changes in PR https://github.com/JuliaMath/FixedPointDecimals.jl/pull/45/ introduced a type instability I didn't know about. I fixed it and added unit tests for type stability of multiplication in these two commits, [#45/files/beb1d3..11ee5e14](https://github.com/JuliaMath/FixedPointDecimals.jl/pull/45/files/beb1d3a3e1bf7a0083ed362af3bf12b8c0b0ff65..11ee5e14899508dd706bfeeadf180dfb47c5c0da), but I think that a nicer solution might just be to add type-stability tests across the whole API, so that these kinds of mistakes would be caught in the future. :)

This is a test-only change so hopefully is easy to review. :)
Cheers!