### PR TITLE
Add support for three-arg `div` to FixedDecimals in Julia 1.4+

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -300,12 +300,14 @@ end
 for remfn in [:rem, :mod, :mod1, :min, :max]
     @eval $remfn(x::T, y::T) where {T <: FD} = reinterpret(T, $remfn(x.i, y.i))
 end
-for divfn in [:div, :fld, :fld1]
+for divfn in [:div, :fld, :fld1, :cld]
     # div(x.i, y.i) eliminates the scaling coefficient, so we call the FD constructor.
     # We don't need any widening logic, since we won't be multiplying by the coefficient.
-    @eval $divfn(x::T, y::T) where {T <: FD} = T($divfn(x.i, y.i))
+    @eval Base.$divfn(x::T, y::T) where {T <: FD} = T($divfn(x.i, y.i))
 end
 if VERSION >= v"1.4.0-"
+    # div(x.i, y.i) eliminates the scaling coefficient, so we call the FD constructor.
+    # We don't need any widening logic, since we won't be multiplying by the coefficient.
     Base.div(x::T, y::T, r::RoundingMode) where {T <: FD} = T(div(x.i, y.i, r))
 end
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -300,6 +300,8 @@ end
 for remfn in [:rem, :mod, :mod1, :min, :max]
     @eval $remfn(x::T, y::T) where {T <: FD} = reinterpret(T, $remfn(x.i, y.i))
 end
+# TODO: When we upgrade to a min julia version >=1.4 (i.e Julia 2.0), this block can be
+# dropped in favor of three-argument `div`, below.
 for divfn in [:div, :fld, :fld1, :cld]
     # div(x.i, y.i) eliminates the scaling coefficient, so we call the FD constructor.
     # We don't need any widening logic, since we won't be multiplying by the coefficient.

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -305,6 +305,9 @@ for divfn in [:div, :fld, :fld1]
     # We don't need any widening logic, since we won't be multiplying by the coefficient.
     @eval $divfn(x::T, y::T) where {T <: FD} = T($divfn(x.i, y.i))
 end
+if VERSION >= v"1.4.0-"
+    Base.div(x::T, y::T, r::RoundingMode) where {T <: FD} = T(div(x.i, y.i, r))
+end
 
 convert(::Type{AbstractFloat}, x::FD) = convert(floattype(typeof(x)), x)
 function convert(::Type{TF}, x::FD{T, f}) where {TF <: AbstractFloat, T, f}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -536,6 +536,16 @@ end
 
         @test one(FD{Int32, 2}) ÷ one(FD{Int64, 6}) isa FD{Int64, 6}
     end
+
+    @testset "div with rounding modes" begin
+        if VERSION >= v"1.4.0-"
+            @testset for x in keyvalues[FD2]
+                for R in (RoundUp, RoundDown, RoundNearest, RoundNearestTiesAway)
+                    @test div(x, 2one(x), R) === div(x, 2, R) === FD2(div(x.i, FD2(2).i, R))
+                end
+            end
+        end
+    end
 end
 
 @testset "abs, sign" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -540,7 +540,8 @@ end
     @testset "div with rounding modes" begin
         if VERSION >= v"1.4.0-"
             @testset for x in keyvalues[FD2]
-                for R in (RoundUp, RoundDown, RoundNearest, RoundNearestTiesAway)
+                # TODO: Test RoundFromZero -- https://github.com/JuliaLang/julia/issues/34519
+                for R in (RoundToZero, RoundUp, RoundDown, RoundNearest, RoundNearestTiesAway)
                     @test div(x, 2one(x), R) === div(x, 2, R) === FD2(div(x.i, FD2(2).i, R))
                 end
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -545,6 +545,9 @@ end
                 end
             end
         end
+        @testset for x in keyvalues[FD2], f in (fld, cld, fld1, div)
+            @test f(x, 2one(x)) === f(x, 2) === FD2(f(x.i, FD2(2).i))
+        end
     end
 end
 


### PR DESCRIPTION
This PR adds support for three-arg div by implementing `div(x,y,::RoundingMode)` for FixedDecimals that delegates to `div` of the fields.

**Remaining question:** Is this enough? Do we also need to implement the three-arg `fld`, `mod`, etc?

Fixes #50.