### PR TITLE
Add support for rem(x,y,::RoundingMode) for FixedDecimals

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -294,6 +294,15 @@ end
 for remfn in [:rem, :mod, :mod1, :min, :max]
     @eval Base.$remfn(x::T, y::T) where {T <: FD} = reinterpret(T, $remfn(x.i, y.i))
 end
+if VERSION >= v"1.4.0-"
+    # TODO: Add support for (RoundFromZero, RoundNearest, RoundNearestTiesAway), which
+    #       aren't supported for Ints.
+    for R in (RoundToZero, RoundUp, RoundDown)
+        RType = typeof(R)
+        Base.rem(x::T, y::T, r::RType) where {T <: FD} = reinterpret(T, rem(x.i, y.i, r))
+    end
+end
+
 # TODO: When we upgrade to a min julia version >=1.4 (i.e Julia 2.0), this block can be
 # dropped in favor of three-argument `div`, below.
 for divfn in [:div, :fld, :fld1, :cld]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -537,13 +537,26 @@ end
         @test one(FD{Int32, 2}) ÷ one(FD{Int64, 6}) isa FD{Int64, 6}
     end
 
+    @testset "rem with rounding modes" begin
+        if VERSION >= v"1.4.0-"
+            # TODO: Test RoundFromZero, RoundNearest, RoundNearestTiesAway
+            #       See: https://github.com/JuliaLang/julia/issues/34519
+            @testset for x in keyvalues[FD2],
+                         R in (RoundToZero, RoundUp, RoundDown)
+                @test rem(x, 2one(x), R) === rem(x, 2, R) === reinterpret(FD2, rem(x.i, FD2(2).i, R))
+            end
+        end
+        @testset for x in keyvalues[FD2], f in (fld, cld, fld1, div)
+            @test f(x, 2one(x)) === f(x, 2) === FD2(f(x.i, FD2(2).i))
+        end
+    end
+
     @testset "div with rounding modes" begin
         if VERSION >= v"1.4.0-"
-            @testset for x in keyvalues[FD2]
-                # TODO: Test RoundFromZero -- https://github.com/JuliaLang/julia/issues/34519
-                for R in (RoundToZero, RoundUp, RoundDown, RoundNearest, RoundNearestTiesAway)
-                    @test div(x, 2one(x), R) === div(x, 2, R) === FD2(div(x.i, FD2(2).i, R))
-                end
+            # TODO: Test RoundFromZero -- https://github.com/JuliaLang/julia/issues/34519
+            @testset for x in keyvalues[FD2],
+                         R in (RoundToZero, RoundUp, RoundDown, RoundNearest, RoundNearestTiesAway)
+                @test div(x, 2one(x), R) === div(x, 2, R) === FD2(div(x.i, FD2(2).i, R))
             end
         end
         @testset for x in keyvalues[FD2], f in (fld, cld, fld1, div)


### PR DESCRIPTION
However, the simple overload does not seem to work, since it is
ambiguous with `rem(x,y,::RoundingMode{Up})`, for example, so for `rem`,
we're manually overloading all RoundingModes.