### PR TITLE
Add version to Project.toml, and bump to 0.3.1.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,7 @@
 name = "FixedPointDecimals"
 uuid = "fb4d412d-6eee-574d-9565-ede6634db7b0"
 authors = ["Fengyang Wang <fengyang.wang.0@gmail.com>", "Curtis Vogt <curtis.vogt@gmail.com>"]
+version = "0.3.1"
 
 [compat]
 julia = "0.7, 1.0"


### PR DESCRIPTION
This pull request adds `version` to Project.toml, and bumps `version` to 0.3.1 for downstream tagging/registration. These changes should address https://github.com/JuliaMath/FixedPointDecimals.jl/issues/59, i.e. functionality under Julia 1.6. Best! :)