### PR TITLE
Change an array to a tuple to improve parsing performance by 10x

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -402,7 +402,7 @@ Raises an `InexactError` if any rounding is necessary.
 const RoundThrows = RoundingMode{:Throw}()
 
 function Base.parse(::Type{FD{T, f}}, str::AbstractString, mode::RoundingMode=RoundNearest) where {T, f}
-    if !(mode in [RoundThrows, RoundNearest, RoundToZero])
+    if !(mode in (RoundThrows, RoundNearest, RoundToZero))
         throw(ArgumentError("Unhandled rounding mode $mode"))
     end
 


### PR DESCRIPTION
```julia
function parse_direct(n_str::AbstractString)
    return parse(FixedDecimal{Int, 2}, n_str)
end
```

Before:
```
julia> @benchmark parse_direct(t)
BenchmarkTools.Trial:
  memory estimate:  320 bytes
  allocs estimate:  8
  --------------
  minimum time:     2.070 μs (0.00% GC)
  median time:      2.385 μs (0.00% GC)
  mean time:        2.627 μs (0.00% GC)
  maximum time:     73.575 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     9
```

After:
```
julia> @benchmark parse_direct(t)
BenchmarkTools.Trial:
  memory estimate:  208 bytes
  allocs estimate:  7
  --------------
  minimum time:     206.502 ns (0.00% GC)
  median time:      226.154 ns (0.00% GC)
  mean time:        249.511 ns (1.97% GC)
  maximum time:     3.213 μs (90.62% GC)
  --------------
  samples:          10000
  evals/sample:     492
```