### PR TITLE
specialize signbit(::FixedDecimal)

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -354,6 +354,9 @@ Base.eps(x::FD) = eps(typeof(x))
 Base.floatmin(::Type{T}) where {T <: FD} = eps(T)
 Base.floatmax(::Type{T}) where {T <: FD} = typemax(T)
 
+# the default implementation of signbit is slow for BigInts and Int128s
+Base.signbit(x::FD) = signbit(x.i)
+
 # printing
 function Base.print(io::IO, x::FD{T, 0}) where T
     print(io, x.i)


### PR DESCRIPTION
The default implementation of `signbit` is quite slow for `BigInt` and `Int128`.
MWE:
```julia
using FixedPointDecimals
using BenchmarkTools

signbit2(x) = signbit(x.i);

x = FixedDecimal{BigInt, 10}(1);
@btime signbit($x);
@btime signbit2($x);

x = FixedDecimal{Int128, 10}(1);
@btime signbit($x);
@btime signbit2($x);
```