### PR TITLE
Fix promotion between FixedDecimal and Rational

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -328,7 +328,7 @@ end
 
 Base.promote_rule(::Type{FD{T, f}}, ::Type{<:Integer}) where {T, f} = FD{T, f}
 Base.promote_rule(::Type{<:FD}, ::Type{TF}) where {TF <: AbstractFloat} = TF
-Base.promote_rule(::Type{<:FD}, ::Type{Rational{TR}}) where {TR} = Rational{TR}
+Base.promote_rule(::Type{<:FD{T}}, ::Type{Rational{TR}}) where {T, TR} = Rational{promote_type(T, TR)}
 
 # TODO: decide if these are the right semantics;
 # right now we pick the bigger int type and the bigger decimal point

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -266,6 +266,12 @@ end
     @test 1 + FD2(0.1) === FD2(1.1)
     @test FD2(0.1) + FD4(0.0001) === FD4(0.1001)
     @test WFD2(0.1) + FD4(0.0001) === WFD4(0.1001)
+
+    # promotion with Rational
+    # see https://github.com/JuliaMath/FixedPointDecimals.jl/issues/73
+    r = Rational{Int8}(1//1)
+    fd = FixedDecimal{Int128,4}(2.5806)
+    @test (r + fd) isa Rational{Int128}
 end
 
 @testset "float" begin


### PR DESCRIPTION
- close #73
- when promoting to `Rational` we now always use the bigger of the integer types being used by the `Rational` or the `FixedDecimal`, in order to avoid an `InexactError` when trying to convert a large integer (from `FixedDecimal`) into a smaller integer (in `Rational`)