### PR TITLE
Use a `Parsers.jl`-based parser implementation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
 #          - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.4.2"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 
 [compat]
+Parsers = "2.7"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "fb4d412d-6eee-574d-9565-ede6634db7b0"
 authors = ["Fengyang Wang <fengyang.wang.0@gmail.com>", "Curtis Vogt <curtis.vogt@gmail.com>"]
 version = "0.4.2"
 
+[deps]
+Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+
 [compat]
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FixedPointDecimals"
 uuid = "fb4d412d-6eee-574d-9565-ede6634db7b0"
 authors = ["Fengyang Wang <fengyang.wang.0@gmail.com>", "Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "0.4.2"
+version = "0.5.0"
 
 [deps]
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FixedPointDecimals"
 uuid = "fb4d412d-6eee-574d-9565-ede6634db7b0"
 authors = ["Fengyang Wang <fengyang.wang.0@gmail.com>", "Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "0.5.0"
+version = "0.4.3"
 
 [deps]
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -100,12 +100,15 @@ end
 end
 
 const FD = FixedDecimal
+const RoundThrows = RoundingMode{:Throw}()
 
 include("parse.jl")
 
 function __init__()
-    append!(_BIGINT_10s, [BigInt(0) for i in 0:Threads.nthreads()])
-    append!(_BIGINT_Rs, [BigInt(0) for i in 0:Threads.nthreads()])
+    nt = isdefined(Base.Threads, :maxthreadid) ? Threads.maxthreadid() : Threads.nthreads()
+    # Buffers used in parsing when dealing with BigInts, see _divpow10! in parse.jl
+    resize!(empty!(_BIGINT_10s), nt)
+    resize!(empty!(_BIGINT_Rs), nt)
 end
 
 (::Type{T})(x::Real) where {T <: FD} = convert(T, x)

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -100,7 +100,6 @@ end
 end
 
 const FD = FixedDecimal
-const RoundThrows = RoundingMode{:Throw}()
 
 include("parse.jl")
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -28,6 +28,7 @@ module FixedPointDecimals
 export FixedDecimal, RoundThrows
 
 using Base: decompose, BitInteger
+import Parsers
 
 # floats that support fma and are roughly IEEE-like
 const FMAFloat = Union{Float16, Float32, Float64, BigFloat}
@@ -99,6 +100,13 @@ end
 end
 
 const FD = FixedDecimal
+
+include("parse.jl")
+
+function __init__()
+    append!(_BIGINT_10s, [BigInt(0) for i in 0:Threads.nthreads()])
+    append!(_BIGINT_Rs, [BigInt(0) for i in 0:Threads.nthreads()])
+end
 
 (::Type{T})(x::Real) where {T <: FD} = convert(T, x)
 
@@ -411,77 +419,6 @@ function Base.show(io::IO, x::FD{T, f}) where {T, f}
     if !iscompact
         print(io, ')')
     end
-end
-
-# parsing
-
-"""
-    RoundThrows
-
-Raises an `InexactError` if any rounding is necessary.
-"""
-const RoundThrows = RoundingMode{:Throw}()
-
-function Base.parse(::Type{FD{T, f}}, str::AbstractString, mode::RoundingMode=RoundNearest) where {T, f}
-    if !(mode in (RoundThrows, RoundNearest, RoundToZero))
-        throw(ArgumentError("Unhandled rounding mode $mode"))
-    end
-
-    # Parse exponent information
-    exp_index = something(findfirst(==('e'), str), 0)
-    if exp_index > 0
-        exp = parse(Int, str[(exp_index + 1):end])
-        sig_end = exp_index - 1
-    else
-        exp = 0
-        sig_end = lastindex(str)
-    end
-
-    # Remove the decimal place from the string
-    sign = T(first(str) == '-' ? -1 : 1)
-    dec_index = something(findfirst(==('.'), str), 0)
-    sig_start = sign < 0 ? 2 : 1
-    if dec_index > 0
-        int_str = str[sig_start:(dec_index - 1)] * str[(dec_index + 1):sig_end]
-        exp -= sig_end - dec_index
-    else
-        int_str = str[sig_start:sig_end]
-    end
-
-    # Split the integer string into the value we can represent inside the FixedDecimal and
-    # the remaining digits we'll use during rounding
-    int_end = lastindex(int_str)
-    pivot = int_end + exp - (-f)
-
-    a = rpad(int_str[1:min(pivot, int_end)], pivot, '0')
-    b = lpad(int_str[max(pivot, 1):int_end], int_end - pivot + 1, '0')
-
-    # Parse the strings
-    val = isempty(a) ? T(0) : sign * parse(T, a)
-    if !isempty(b) && any(!isequal('0'), b[2:end])
-        if mode == RoundThrows
-            throw(InexactError(:parse, FD{T, f}, str))
-        elseif mode == RoundNearest
-            val += sign * parse_round(T, b, mode)
-        end
-    end
-
-    reinterpret(FD{T, f}, val)
-end
-
-function parse_round(::Type{T}, fractional::AbstractString, ::RoundingMode{:Nearest}) where T
-    # Note: parsing each digit individually ensures we don't run into an OverflowError
-    digits = Int8[parse(Int8, d) for d in fractional]
-    for i in length(digits):-1:2
-        if digits[i] > 5 || digits[i] == 5 && isodd(digits[i - 1])
-            if i - 1 == 1
-                return T(1)
-            else
-                digits[i - 1] += 1
-            end
-        end
-    end
-    return T(0)
 end
 
 

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -1,0 +1,341 @@
+using Parsers
+using Parsers: AbstractConf, SourceType, XOPTIONS, Result
+
+struct FixedDecimalConf{T<:Integer} <: AbstractConf{T}
+    f::Int
+end
+Parsers.conf(::Type{FixedDecimal{T,f}}, opts::Parsers.Options, kw...) where {T<:Integer,f} = FixedDecimalConf{T}(f)
+
+const OPTIONS_ROUND_NEAREST = Parsers.Options(rounding=RoundNearest)
+const OPTIONS_ROUND_TO_ZERO = Parsers.Options(rounding=RoundToZero)
+const OPTIONS_ROUND_THROWS = Parsers.Options(rounding=nothing)
+
+# like n * 10^decpos, but faster
+@inline function _shift(n::T, decpos) where {T<:Union{UInt128,Int128}}
+    if     decpos ==  0 && return n
+    elseif decpos ==  1 && return T(10) * n
+    elseif decpos ==  2 && return T(100) * n
+    elseif decpos ==  3 && return T(1000) * n
+    elseif decpos ==  4 && return T(10000) * n
+    elseif decpos ==  5 && return T(100000) * n
+    elseif decpos ==  6 && return T(1000000) * n
+    elseif decpos ==  7 && return T(10000000) * n
+    elseif decpos ==  8 && return T(100000000) * n
+    elseif decpos ==  9 && return T(1000000000) * n
+    elseif decpos == 10 && return T(10000000000) * n
+    elseif decpos == 11 && return T(100000000000) * n
+    elseif decpos == 12 && return T(1000000000000) * n
+    elseif decpos == 13 && return T(10000000000000) * n
+    elseif decpos == 14 && return T(100000000000000) * n
+    elseif decpos == 15 && return T(1000000000000000) * n
+    elseif decpos == 16 && return T(10000000000000000) * n
+    elseif decpos == 17 && return T(100000000000000000) * n
+    elseif decpos == 18 && return T(1000000000000000000) * n
+    elseif decpos == 19 && return T(10000000000000000000) * n
+    elseif decpos == 20 && return T(100000000000000000000) * n
+    elseif decpos == 21 && return T(1000000000000000000000) * n
+    elseif decpos == 22 && return T(10000000000000000000000) * n
+    elseif decpos == 23 && return T(100000000000000000000000) * n
+    elseif decpos == 24 && return T(1000000000000000000000000) * n
+    elseif decpos == 25 && return T(10000000000000000000000000) * n
+    elseif decpos == 26 && return T(100000000000000000000000000) * n
+    elseif decpos == 27 && return T(1000000000000000000000000000) * n
+    elseif decpos == 28 && return T(10000000000000000000000000000) * n
+    elseif decpos == 29 && return T(100000000000000000000000000000) * n
+    elseif decpos == 30 && return T(1000000000000000000000000000000) * n
+    elseif decpos == 31 && return T(10000000000000000000000000000000) * n
+    elseif decpos == 32 && return T(100000000000000000000000000000000) * n
+    elseif decpos == 33 && return T(1000000000000000000000000000000000) * n
+    elseif decpos == 34 && return T(10000000000000000000000000000000000) * n
+    elseif decpos == 35 && return T(100000000000000000000000000000000000) * n
+    elseif decpos == 36 && return T(1000000000000000000000000000000000000) * n
+    elseif decpos == 37 && return T(10000000000000000000000000000000000000) * n
+    elseif decpos == 38 && return T(100000000000000000000000000000000000000) * n
+    elseif decpos == 39 && return T(1000000000000000000000000000000000000000) * n
+    else
+        @assert false # unreachable
+    end
+end
+
+@inline function _shift(n::T, decpos) where {T<:Union{UInt64,Int64}}
+    if     decpos ==  0 && return n
+    elseif decpos ==  1 && return T(10) * n
+    elseif decpos ==  2 && return T(100) * n
+    elseif decpos ==  3 && return T(1000) * n
+    elseif decpos ==  4 && return T(10000) * n
+    elseif decpos ==  5 && return T(100000) * n
+    elseif decpos ==  6 && return T(1000000) * n
+    elseif decpos ==  7 && return T(10000000) * n
+    elseif decpos ==  8 && return T(100000000) * n
+    elseif decpos ==  9 && return T(1000000000) * n
+    elseif decpos == 10 && return T(10000000000) * n
+    elseif decpos == 11 && return T(100000000000) * n
+    elseif decpos == 12 && return T(1000000000000) * n
+    elseif decpos == 13 && return T(10000000000000) * n
+    elseif decpos == 14 && return T(100000000000000) * n
+    elseif decpos == 15 && return T(1000000000000000) * n
+    elseif decpos == 16 && return T(10000000000000000) * n
+    elseif decpos == 17 && return T(100000000000000000) * n
+    elseif decpos == 18 && return T(1000000000000000000) * n
+    elseif decpos == 19 && return T(10000000000000000000) * n
+    elseif decpos == 20 && return T(100000000000000000000) * n
+    else
+        @assert false # unreachable
+    end
+end
+
+@inline function _shift(n::T, decpos) where {T<:Union{UInt32,Int32}}
+    if     decpos ==  0 && return n
+    elseif decpos ==  1 && return T(10) * n
+    elseif decpos ==  2 && return T(100) * n
+    elseif decpos ==  3 && return T(1000) * n
+    elseif decpos ==  4 && return T(10000) * n
+    elseif decpos ==  5 && return T(100000) * n
+    elseif decpos ==  6 && return T(1000000) * n
+    elseif decpos ==  7 && return T(10000000) * n
+    elseif decpos ==  8 && return T(100000000) * n
+    elseif decpos ==  9 && return T(1000000000) * n
+    elseif decpos == 10 && return T(10000000000) * n
+    else
+        @assert false # unreachable
+    end
+end
+
+@inline function _shift(n::T, decpos) where {T<:Union{UInt16,Int16}}
+    if     decpos == 0 && return n
+    elseif decpos == 1 && return T(10) * n
+    elseif decpos == 2 && return T(100) * n
+    elseif decpos == 3 && return T(1000) * n
+    elseif decpos == 4 && return T(10000) * n
+    elseif decpos == 5 && return T(100000) * n
+    else
+        @assert false # unreachable
+    end
+end
+
+@inline function _shift(n::T, decpos) where {T<:Union{UInt8,Int8}}
+    if     decpos == 0 && return n
+    elseif decpos == 1 && return T(10) * n
+    elseif decpos == 2 && return T(100) * n
+    elseif decpos == 3 && return T(1000) * n
+    else
+        @assert false # unreachable
+    end
+end
+
+const _BIGINT1 = BigInt(1)
+const _BIGINT2 = BigInt(2)
+const _BIGINT10 = BigInt(10)
+const _BIGINT_10s = BigInt[] # buffer for "remainders" in _divpow10!, accessed via `Parsers.access_threaded`
+const _BIGINT_Rs = BigInt[]  # buffer for "remainders" in _divpow10!, accessed via `Parsers.access_threaded`
+
+for T in (Base.BitSigned_types..., Base.BitUnsigned_types...)
+    let bytes = Tuple(codeunits(string(typemax(T))))
+        # The number of digits an integer of type T can hold
+        @eval _maxintdigits(::Type{$T}) = $(length(bytes))
+    end
+end
+
+# All `v`s either UInt64, UInt128 and positive Integers
+function _unsafe_convert_int(::Type{T}, v::V) where {T<:Integer,V<:Integer}
+    return sizeof(T) > sizeof(V) ? T(v) :
+           sizeof(T) < sizeof(V) ? unsafe_trunc(T, v) :
+           Base.bitcast(T, v)
+end
+_unsafe_convert_int(::Type{T}, v::BigInt) where {T<:Integer} = unsafe_trunc(T, v)
+_unsafe_convert_int(::Type{T}, v::T) where {T<:Integer} = v
+
+function _check_overflows(::Type{T}, v::BigInt, neg::Bool) where {T<:Integer}
+    return neg ? -v < typemin(T) : v > typemax(T)
+end
+function _check_overflows(::Type{T}, v::V, neg::Bool) where {T<:Integer,V<:Union{UInt64,UInt128}}
+    return sizeof(T) <= sizeof(V) && (neg ? v > _unsafe_convert_int(V, typemax(T)) + one(V) : v > typemax(T))
+end
+_check_overflows(::Type{T}, v::T, neg::Bool) where {T <: Integer} = false
+
+# `x = div(x, 10^pow, mode)`; may set code |= INEXACT for RoundThrows
+# x is non-negative, pow is >= 1
+# `!` to signal we mutate bigints in-place
+function _divpow10!(x::T, code, pow, mode::RoundingMode) where {T}
+    return div(x, _shift(one(T), pow), mode), code
+end
+function _divpow10!(x::T, code, pow, ::RoundingMode{:Throw}) where {T}
+    q, r = divrem(x, _shift(one(T), pow))
+    r == 0 || (code |= Parsers.INEXACT)
+    return q, code
+end
+function _divpow10!(x::BigInt, code, pow, ::RoundingMode{:Nearest})
+    # adapted from https://github.com/JuliaLang/julia/blob/112554e1a533cebad4cb0daa27df59636405c075/base/div.jl#L217
+    @inbounds r = Parsers.access_threaded(() -> (@static VERSION > v"1.5" ? BigInt(; nbits=256) : BigInt()), _BIGINT_Rs)  # we must not yield here!
+    @inbounds y = Parsers.access_threaded(() -> (@static VERSION > v"1.5" ? BigInt(; nbits=256) : BigInt()), _BIGINT_10s) # we must not yield here!
+    Base.GMP.MPZ.set!(y, _BIGINT10)             # y = 10
+    Base.GMP.MPZ.pow_ui!(y, pow)                # y = y^pow
+    Base.GMP.MPZ.tdiv_qr!(x, r, x, y)           # x, r = divrem(x, y)
+    Base.GMP.MPZ.tdiv_q!(y, _BIGINT2)           # y = div(y, 2)
+    iseven(x) && Base.GMP.MPZ.add!(y, _BIGINT1) # y = y + iseven(x)
+    if r >= y
+        Base.GMP.MPZ.add!(x, _BIGINT1)          # x = x + (r >= y)
+    end
+    return x, code
+end
+function _divpow10!(x::BigInt, code, pow, ::RoundingMode{:ToZero})
+    @inbounds y = Parsers.access_threaded(() -> (@static VERSION > v"1.5" ? BigInt(; nbits=256) : BigInt()), _BIGINT_10s) # we must not yield here!
+    Base.GMP.MPZ.set!(y, _BIGINT10) # y = 10
+    Base.GMP.MPZ.pow_ui!(y, pow)    # y = y^pow
+    Base.GMP.MPZ.tdiv_q!(x, y)      # x = div(x, y)
+    return x, code
+end
+
+function _divpow10!(x::BigInt, code, pow, ::RoundingMode{:Throw})
+    @inbounds y = Parsers.access_threaded(() -> (@static VERSION > v"1.5" ? BigInt(; nbits=256) : BigInt()), _BIGINT_10s) # we must not yield here!
+    Base.GMP.MPZ.set!(y, _BIGINT10)   # y = 10
+    Base.GMP.MPZ.pow_ui!(y, pow)      # y = y^pow
+    Base.GMP.MPZ.tdiv_qr!(x, y, x, y) # x, y = divrem(x, y)
+    y == 0 || (code |= Parsers.INEXACT)
+    return x, code
+end
+
+# Rescale the digits we accumulated so far into the the a an integer representing the decimal
+@inline function Parsers.scale(
+    conf::FixedDecimalConf{T}, ::Parsers.FloatType, digits::V, exp, neg, code, ndigits, f::F, options::Parsers.Options
+) where {T,V,F}
+    rounding = something(options.rounding, RoundThrows)
+    # Positive: how many trailing zeroes we need to add to out integer
+    # Negative: how many digits are past our precision (we need to handle them in rounding)
+    decimal_shift = conf.f + exp
+    # Number of digits we need to accumulate including any trailigng zeros or digits past our precision
+    backing_integer_digits = ndigits + decimal_shift
+    may_overflow = backing_integer_digits == _maxintdigits(T)
+    if iszero(ndigits)
+        # all digits are zero
+        i = zero(T)
+    elseif backing_integer_digits < 0
+        # All digits are past our precision, no overflow possible
+        i = zero(T)
+        (rounding === RoundThrows) && (code |= Parsers.INEXACT)
+    elseif neg && (T <: Unsigned)
+        # Unsigned types can't represent negative numbers
+        i = _unsafe_convert_int(T, digits)
+        code |= Parsers.INVALID
+    elseif backing_integer_digits > _maxintdigits(T)
+        i = _unsafe_convert_int(T, digits)
+        # The number of digits to accumulate is larger than the capacity of T, we overflow
+        # We don't check for inexact here because we already have an error
+        code |= Parsers.OVERFLOW
+    else
+        if decimal_shift > 0
+            r = _unsafe_convert_int(T, digits)
+            i = _shift(r, decimal_shift)
+            may_overflow && (r >= i) && (code |= Parsers.OVERFLOW)
+        elseif decimal_shift < 0
+            if rounding === RoundNearest
+                r, code = _divpow10!(digits, code, -decimal_shift, RoundNearest)
+            elseif rounding === RoundToZero
+                r, code = _divpow10!(digits, code, -decimal_shift, RoundToZero)
+            else
+                r, code = _divpow10!(digits, code, -decimal_shift, RoundThrows)
+            end
+            # Now that the digits were rescaled we can check for overflow
+            # can happen e.g. if digits were unsigned ints and out type is signed
+            may_overflow && _check_overflows(T, r, neg) && (code |= Parsers.OVERFLOW)
+            i = _unsafe_convert_int(T, r)
+        else
+            may_overflow && _check_overflows(T, digits, neg) && (code |= Parsers.OVERFLOW)
+            i = _unsafe_convert_int(T, digits)
+        end
+    end
+    out = ifelse(neg, -i, i)
+    return (out, code)
+end
+
+# If we only saw integer digits and not fractional or exponent digits, we just call scale with exp of 0
+# To handle type conversions and overflow checks etc.
+@inline function Parsers.noscale(conf::FixedDecimalConf{T}, digits::Integer, neg::Bool, code, ndigits, f::F, options::Parsers.Options) where {T,F}
+    FT = Parsers.FLOAT64 # not used by FixedDecimal parser
+    exp = 0
+    return Parsers.scale(conf, FT, digits, exp, neg, code, ndigits, f, options)
+end
+
+# We return a value of T -- i.e. the _integer_ backing the FixedDecimal, the reintrpret needs to happen later
+@inline function Parsers.typeparser(conf::FixedDecimalConf{T}, source, pos, len, b, code, pl, options) where {T<:Integer}
+    if !(options.rounding in (nothing, RoundNearest, RoundToZero, RoundThrows))
+        throw(ArgumentError("Unhandled rounding mode $options.rounding"))
+    end
+
+    startpos = pos
+    code = Parsers.SUCCESS
+
+    # begin parsing
+    neg = b == UInt8('-')
+    if neg || b == UInt8('+')
+        pos += 1
+        Parsers.incr!(source)
+        if Parsers.eof(source, pos, len)
+            code |= Parsers.INVALID | Parsers.EOF
+            x = zero(T)
+            @goto done
+        end
+        b = Parsers.peekbyte(source, pos)
+    else
+        # Check if the input is empty
+        if Parsers.eof(source, pos, len)
+            code |= Parsers.INVALID | Parsers.EOF
+            x = zero(T)
+            @goto done
+        end
+    end
+
+    if (b - UInt8('0')) <= 0x09 || b == options.decimal
+        x, code, pos = Parsers.parsedigits(conf, source, pos, len, b, code, options, UInt64(0), neg, startpos, true, 0, nothing)
+    else
+        x = zero(T)
+        code |= Parsers.INVALID
+    end
+    @label done
+    return pos, code, Parsers.PosLen(pl.pos, pos - pl.pos), x
+end
+
+Parsers.supportedtype(::Type{FixedDecimal{T,f}}) where {T<:Integer,f} = true
+
+function Parsers.xparse(::Type{FixedDecimal{T,f}}, source::SourceType, pos, len, options=XOPTIONS, ::Type{S}=FixedDecimal{T,f}) where {T<:Integer,f,S}
+    buf = source isa AbstractString ? codeunits(source) : source
+    # TODO: remove @noinline after Parsers is updated
+    res = @noinline Parsers._xparse(FixedDecimalConf{T}(f), buf, pos, len, options, T)
+    return Result{S}(res.code, res.tlen, reinterpret(S, res.val))
+end
+
+function Parsers.xparse2(::Type{FixedDecimal{T,f}}, source::SourceType, pos, len, options=XOPTIONS, ::Type{S}=FixedDecimal{T,f}) where {T<:Integer,f,S}
+    buf = source isa AbstractString ? codeunits(source) : source
+    # TODO: remove @noinline after Parsers is updated
+    res = @noinline Parsers._xparse2(FixedDecimalConf{T}(f), buf, pos, len, options, T)
+    return Result{S}(res.code, res.tlen, reinterpret(S, res.val))
+end
+
+function _base_parse(::Type{FD{T, f}}, source::AbstractString, mode::RoundingMode=RoundNearest) where {T, f}
+    if !(mode in (RoundThrows, RoundNearest, RoundToZero))
+        throw(ArgumentError("Unhandled rounding mode $mode"))
+    end
+
+    isempty(source) && throw(("Empty input is not allowed"))
+    bytes = codeunits(source)
+    options = mode === RoundNearest ? OPTIONS_ROUND_NEAREST :
+        mode === RoundToZero ? OPTIONS_ROUND_TO_ZERO :
+        OPTIONS_ROUND_THROWS
+    res = Parsers.xparse2(FD{T, f}, bytes, 1, length(bytes), options)
+    return res
+end
+
+function Base.tryparse(::Type{FD{T, f}}, source::AbstractString, mode::RoundingMode=RoundNearest) where {T, f}
+    res = _base_parse(FD{T, f}, source, mode)
+    # If we didn't reach eof, there was some garbage at the end of the string after something that looked like a number
+    return (Parsers.eof(res.code) && Parsers.ok(res.code)) ? res.val : nothing
+end
+
+function Base.parse(::Type{FD{T, f}}, source::AbstractString, mode::RoundingMode=RoundNearest) where {T, f}
+    res = _base_parse(FD{T, f}, source, mode)
+    Parsers.inexact(res.code) && throw(InexactError(:parse, FD{T, f}, source))
+    Parsers.overflow(res.code) && throw(OverflowError("overflow parsing $(repr(source)) as $(FD{T, f})"))
+    # If we didn't reach eof, there was some garbage at the end of the string after something that looked like a number
+    (!Parsers.eof(res.code) || Parsers.invalid(res.code)) && throw(ArgumentError("cannot parse $(repr(source)) as $(FD{T, f})"))
+    return res.val
+end

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -213,7 +213,6 @@ function _base_parse(::Type{FD{T, f}}, source::AbstractString, mode::RoundingMod
         throw(ArgumentError("Unhandled rounding mode $mode"))
     end
 
-    isempty(source) && throw(("Empty input is not allowed"))
     bytes = codeunits(source)
     options = mode === RoundNearest ? OPTIONS_ROUND_NEAREST :
         mode === RoundToZero ? OPTIONS_ROUND_TO_ZERO :
@@ -223,12 +222,14 @@ function _base_parse(::Type{FD{T, f}}, source::AbstractString, mode::RoundingMod
 end
 
 function Base.tryparse(::Type{FD{T, f}}, source::AbstractString, mode::RoundingMode=RoundNearest) where {T, f}
+    isempty(source) && return nothing
     res = _base_parse(FD{T, f}, source, mode)
     # If we didn't reach eof, there was some garbage at the end of the string after something that looked like a number
     return (Parsers.eof(res.code) && Parsers.ok(res.code)) ? res.val : nothing
 end
 
 function Base.parse(::Type{FD{T, f}}, source::AbstractString, mode::RoundingMode=RoundNearest) where {T, f}
+    isempty(source) && throw(ArgumentError("Empty input is not allowed"))
     res = _base_parse(FD{T, f}, source, mode)
     Parsers.inexact(res.code) && throw(InexactError(:parse, FD{T, f}, source))
     Parsers.overflow(res.code) && throw(OverflowError("overflow parsing $(repr(source)) as $(FD{T, f})"))

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -174,7 +174,7 @@ end
 # We return a value of T -- i.e. the _integer_ backing the FixedDecimal, the reintrpret needs to happen later
 @inline function Parsers.typeparser(conf::FixedDecimalConf{T}, source, pos, len, b, code, pl, options) where {T<:Integer}
     if !(options.rounding in (nothing, RoundNearest, RoundToZero, RoundThrows))
-        throw(ArgumentError("Unhandled rounding mode $options.rounding"))
+        throw(ArgumentError("Unhandled rounding mode $(options.rounding)"))
     end
 
     startpos = pos

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -22,6 +22,7 @@ const OPTIONS_ROUND_NEAREST = Parsers.Options(rounding=RoundNearest)
 const OPTIONS_ROUND_TO_ZERO = Parsers.Options(rounding=RoundToZero)
 const OPTIONS_ROUND_THROWS = Parsers.Options(rounding=nothing)
 
+# TODO: a lookup table per type would be faster
 @inline _shift(n::T, decpos) where {T} = T(10)^decpos * n
 
 const _BIGINT1 = BigInt(1)
@@ -37,7 +38,7 @@ for T in (Base.BitSigned_types..., Base.BitUnsigned_types...)
     end
 end
 
-# All `v`s either UInt64, UInt128 and positive Integers
+# All `v`s are non-negative
 function _unsafe_convert_int(::Type{T}, v::V) where {T<:Integer,V<:Integer}
     return sizeof(T) > sizeof(V) ? T(v) :
            sizeof(T) < sizeof(V) ? unsafe_trunc(T, v) :

--- a/test/parse_tests.jl
+++ b/test/parse_tests.jl
@@ -402,8 +402,8 @@ end
     end
 
     @test Parsers.xparse(FixedDecimal{Int,8}, "2", groupmark=',', delim=',', decimal='.', quoted=true).val == FixedDecimal{Int,8}(2)
-    @test Parsers.xparse(FixedDecimal{Int,8}, "\" 2000.0 \"", groupmark=',', delim=',', decimal='.', quoted=true).val == FixedDecimal{Int,8}(2000)
-    @test Parsers.xparse(FixedDecimal{Int,8}, "\" 2,000.0 \"", groupmark=',', delim=',', decimal='.', quoted=true).val == FixedDecimal{Int,8}(2000)
+    @test Parsers.xparse(FixedDecimal{Int,4}, "\" 2000.0 \"", groupmark=',', delim=',', decimal='.', quoted=true).val == FixedDecimal{Int,4}(2000)
+    @test Parsers.xparse(FixedDecimal{Int,4}, "\" 2,000.0 \"", groupmark=',', delim=',', decimal='.', quoted=true).val == FixedDecimal{Int,4}(2000)
 end
 
 @testset "misc options" begin

--- a/test/parse_tests.jl
+++ b/test/parse_tests.jl
@@ -1,0 +1,428 @@
+using Test
+import Parsers
+using FixedPointDecimals
+using FixedPointDecimals: _maxintdigits
+
+# Compat with test contexts introduced in 1.9
+if VERSION >= v"1.9"
+    var"@testctx" = Test.var"@testset"
+else
+    macro testctx(ex)
+        esc(ex)
+    end
+end
+
+const DELIM=';';
+const GROUP=',';
+const DECIM='.';
+const OPTIONS_NEAREST = Parsers.Options(groupmark=GROUP, decimal=DECIM, delim=DELIM, quoted=true, rounding=RoundNearest)
+const OPTIONS_TOZERO = Parsers.Options(groupmark=GROUP, decimal=DECIM, delim=DELIM, quoted=true, rounding=RoundToZero)
+const OPTIONS_THROWS = Parsers.Options(groupmark=GROUP, decimal=DECIM, delim=DELIM, quoted=true, rounding=nothing)
+function test_decimal_parser(::Type{T}, f, buf::AbstractString; ok=true, inexact=false, expect=nothing, options = OPTIONS_NEAREST) where {T}
+    delim = options.delim.token
+    b = get(codeunits(buf), 1, 0xff)
+    pl = Parsers.PosLen(1, length(buf))
+    conf = FixedPointDecimals.FixedDecimalConf{T}(f)
+    (pos, code, _, val) = Parsers.typeparser(conf, codeunits(buf), 1, length(buf), b, Parsers.SUCCESS, pl, options)
+    (pos_io, code_io, _, val_io) = Parsers.typeparser(conf, IOBuffer(buf), 1, length(buf), b, Parsers.SUCCESS, pl, options)
+    @testctx let _ctx="T=$T, f=$f, input=$(repr(string(buf))), code=$(Parsers.text(code)), len=$(length(buf)), pos=$pos, delim=$(repr(Char(delim))), groupmark=$(repr(options.groupmark)), decimal=$(repr(Char(options.decimal))), mode=$(options.rounding), expect=$(repr(expect))"
+        ends_on_delim = !isempty(buf) && UInt8(last(buf)) == UInt8(delim)
+        # We parsed the value (un)successfully as expected
+        @test Parsers.ok(code) == ok
+        @test Parsers.ok(code_io) == ok
+        # We marked the value as inexact as expected
+        @test Parsers.inexact(code) == inexact
+        @test Parsers.inexact(code_io) == inexact
+        # We read all valid bytes, i.e. our current `pos` peeks at one past our input, or the delimiter (which is not a part of the number)
+        ok && (@test pos == (length(buf) + (UInt8(last(buf)) != UInt8(delim))))
+        ok && (@test pos_io == (length(buf) + (UInt8(last(buf)) != UInt8(delim))))
+        # We read all valid bytes and which means that we reached EOF (recovery from invalid input is a job for `Parsers.xparse`)
+        ok && (@test Parsers.eof(code) == !ends_on_delim)
+        ok && (@test Parsers.eof(code_io) == !ends_on_delim)
+        isnothing(expect) || (@test val == expect)
+        isnothing(expect) || (@test val_io == expect)
+        res = Parsers.xparse(FixedDecimal{T,f}, buf, 1, length(buf), options)
+        # Even if the input was not valid, we read it entirely and reached EOF or delim
+        @test Parsers.eof(res.code) == !ends_on_delim
+        @test Parsers.ok(res.code) == ok
+        if ok
+            @test res.val.i == expect # The integer from our typeparser matches the integer from our FixedDecimal
+        else
+            @test Parsers.invalid(res.code) # We parsed the value (un)successfully as expected
+        end
+    end
+    return nothing
+end
+
+insertchar(str, i, c) = str[1:i-1] * c * str[i:end]
+
+const SignedIntegerTypes = (Int8, Int16, Int32, Int64, Int128)
+const UnsignedIntegerTypes = (UInt8, UInt16, UInt32, UInt64, UInt128)
+const IntegerTypes = (SignedIntegerTypes..., UnsignedIntegerTypes...)
+
+@testset "_check_overflows" begin
+    @testset "$T" for T in SignedIntegerTypes
+        @testset "$V" for V in (UInt64, UInt128, BigInt)
+            @test !FixedPointDecimals._check_overflows(T, V(0), true)
+            @test !FixedPointDecimals._check_overflows(T, V(0), false)
+
+            @test !FixedPointDecimals._check_overflows(T, V(1), true)
+            @test !FixedPointDecimals._check_overflows(T, V(1), false)
+
+            if V === BigInt || typemax(T) == typemax(V)
+                @test !FixedPointDecimals._check_overflows(T, V(typemax(T) - 1), true)
+                @test !FixedPointDecimals._check_overflows(T, V(typemax(T) - 1), false)
+
+                @test !FixedPointDecimals._check_overflows(T, V(typemax(T)), true)
+                @test !FixedPointDecimals._check_overflows(T, V(typemax(T)), false)
+            end
+
+            if V === BigInt || typemax(T) < typemax(V)
+                @test !FixedPointDecimals._check_overflows(T, V(V(typemax(T)) + 1), true)
+                @test FixedPointDecimals._check_overflows(T, V(V(typemax(T)) + 1), false)
+
+                @test FixedPointDecimals._check_overflows(T, V(V(typemax(T)) + 2), true)
+                @test FixedPointDecimals._check_overflows(T, V(V(typemax(T)) + 2), false)
+            end
+
+            if V !== BigInt && typemax(T) > typemax(V)
+                @test !FixedPointDecimals._check_overflows(T, typemax(V), true)
+                @test !FixedPointDecimals._check_overflows(T, typemax(V), false)
+            end
+        end
+    end
+end
+
+T = Int64
+f = 8
+@testset "parse" begin
+@testset "1.0" begin
+    @testset "$T" for T in IntegerTypes
+        @testset "$f" for f in 0:(_maxintdigits(T) - 1)
+            expected_value = T(10) ^ f
+            for test_case in [
+                    "1",
+                    "1.",
+                    "1e0",
+                    "1.0",
+                    "1.e0",
+                    "1.000",
+                    "1.0E0",
+                    "1.000e0",
+                    "1.000e-0",
+                    "1.000e+0",
+                    "0.100e+1",
+                    "10.000e-1",
+                    ("0" ^ 99) * "1.0e0",
+                    "1." * ("0" ^ 99) * "e0",
+                    "1" * ("0" ^ 99) * "e-99",
+                    "0." * ("0" ^ 98) * "1E+99",
+                    ("0" ^ 99) * "1." * ("0" ^ 99) * "e0",
+                ]
+                @assert BigFloat(test_case) == 1.0
+                test_decimal_parser(T, f, test_case, expect=expected_value)
+                test_decimal_parser(T, f, "+" * test_case, expect=expected_value)
+                if typemin(T) < 0
+                    test_decimal_parser(T, f, "-" * test_case, expect=-expected_value)
+                end
+            end
+        end
+    end
+end;
+
+@testset "0.0" begin
+    @testset "$T" for T in IntegerTypes
+        @testset "$f" for f in 0:(_maxintdigits(T) - 1)
+            expected_value = 0
+            for test_case in [
+                    "0",
+                    ".0",
+                    "0.",
+                    "0e0",
+                    "0.0",
+                    ".0e0",
+                    "0.e0",
+                    "0.000",
+                    "0.0e0",
+                    "0.000e0",
+                    "0000.e0",
+                    "0.000e-0",
+                    "0.000e+0",
+                    "0.000e-99",
+                    "0.000e+99",
+                ]
+                @assert BigFloat(test_case) == 0.0
+                test_decimal_parser(T, f, test_case, expect=expected_value)
+                test_decimal_parser(T, f, "+" * test_case, expect=expected_value)
+                test_decimal_parser(T, f, "-" * test_case, expect=-expected_value)
+            end
+        end
+    end
+end;
+
+@testset "typemax" begin
+    @testset "$T" for T in IntegerTypes
+        expected_value = typemax(T)
+        @testset "$f" for f in 0:(_maxintdigits(T) - 1)
+            f_comp = (_maxintdigits(T) - f)
+            for test_case in [
+                    # f = 2, T = Int8 | "1.27"
+                    insertchar("$(typemax(T))", f_comp+1, "."),
+                    # f = 2, T = Int8 | "01.27"
+                    "0" * insertchar("$(typemax(T))", f_comp+1, "."),
+                    # f = 2, T = Int8 | "1.27e0"
+                    insertchar("$(typemax(T))", f_comp+1, ".") * "e0",
+                    # f = 2, T = Int8 | "0.00127e+3"
+                    "0." * "0" ^ (f) * "$(typemax(T))" * "e+$(_maxintdigits(T))",
+                    # f = 2, T = Int8 | "12700e-4"
+                    "$(typemax(T))" * "0" ^ f * "e-$(2f)",
+                ]
+                test_decimal_parser(T, f, test_case, expect=expected_value)
+                test_decimal_parser(T, f, "+" * test_case, expect=expected_value)
+            end
+        end
+    end
+end;
+
+@testset "typemin" begin
+    @testset "$T" for T in IntegerTypes
+        expected_value = typemin(T)
+        expected_value == zero(T) && continue
+        val_no_sign = replace(string(expected_value), "-" => "")
+        maybesign = expected_value < zero(T) ? "-" : ""
+        @testset "$f" for f in 0:(_maxintdigits(T) - 1)
+            f_comp = (_maxintdigits(T) - f)
+            for test_case in [
+                    # f = 2, T = Int8 | "-1.28"
+                    maybesign * insertchar("$(val_no_sign)", f_comp+1, "."),
+                    # f = 2, T = Int8 | "-01.28"
+                    maybesign * "0" * insertchar("$(val_no_sign)", f_comp+1, "."),
+                    # f = 2, T = Int8 | "-1.28e0"
+                    maybesign * insertchar("$(val_no_sign)", f_comp+1, ".") * "e0",
+                    # f = 2, T = Int8 | "-0.00128e+3"
+                    maybesign * "0." * "0" ^ (f) * "$(val_no_sign)" * "e+$(_maxintdigits(T))",
+                    # f = 2, T = Int8 | "-12800e-4"
+                    maybesign * "$(val_no_sign)" * "0" ^ f * "e-$(2f)",
+                ]
+                test_decimal_parser(T, f, test_case, expect=expected_value)
+            end
+        end
+    end
+end;
+
+@testset "RoundingMode{:Nearest} " begin
+    options = OPTIONS_NEAREST
+    @testset "$T" for T in IntegerTypes
+        for (base_str, expected_value) in [
+           ("00499", 0),
+           ("004" * ("9" ^ 99), 0),
+           ("00500", 0),
+           ("005" * ("0" ^ 99) * "1", 1),
+           ("00501", 1),
+           ("01499", 1),
+           ("014" * ("9" ^ 99), 1),
+           ("01500", 2),
+           ("015" * ("0" ^ 99) * "1", 2),
+           ("01501", 2),
+        ]
+            # f = 1 | "00.501"
+            test_decimal_parser(T, 1, insertchar(base_str, 2, "."); expect=expected_value, options)
+            # f = 1 | "005.01e-1"
+            test_decimal_parser(T, 1, insertchar(base_str * "e-1", 3, "."); expect=expected_value, options)
+            # f = 1 | "0050.1e-2"
+            test_decimal_parser(T, 1, insertchar(base_str * "e-2", 4, "."); expect=expected_value, options)
+            if typemin(T) < 0
+                # f = 1 | "-00.501"
+                test_decimal_parser(T, 1, "-" * insertchar(base_str, 2, "."); expect=-expected_value, options)
+                # f = 1 | "-005.01e-1"
+                test_decimal_parser(T, 1, "-" * insertchar(base_str * "e-1", 3, "."); expect=-expected_value, options)
+                # f = 1 | "-0050.1e-1"
+                test_decimal_parser(T, 1, "-" * insertchar(base_str * "e-2", 4, "."); expect=-expected_value, options)
+            end
+        end
+        test_decimal_parser(T, 0, ".5"; expect=0, options)
+        test_decimal_parser(T, 0, "0"; expect=0, options)
+        test_decimal_parser(T, 0, "1"; expect=1, options)
+    end
+end;
+
+@testset "RoundingMode{:ToZero} " begin
+    options = OPTIONS_TOZERO
+    @testset "$T" for T in IntegerTypes
+        for (base_str, expected_value) in [
+           ("00001", 0),
+           ("000" * ("0" ^ 99) * "1", 0),
+           ("009", 0),
+           ("009" * ("9" ^ 99), 0),
+           ("01001", 1),
+           ("010" * ("0" ^ 99) * "1", 1),
+           ("019", 1),
+           ("019" * ("9" ^ 99), 1),
+        ]
+            # f = 1 | "0.1999..."
+            test_decimal_parser(T, 1, insertchar(base_str, 2, "."); expect=expected_value, options)
+            # f = 1 | "01.999...e-1"
+            test_decimal_parser(T, 1, insertchar(base_str * "e-1", 3, "."); expect=expected_value, options)
+            # f = 1 | "019.99...e-2"
+            test_decimal_parser(T, 1, insertchar(base_str * "e-2", 4, "."); expect=expected_value, options)
+            if typemin(T) < 0
+                # f = 1 | "-0.1999.."
+                test_decimal_parser(T, 1, "-" * insertchar(base_str, 2, "."); expect=-expected_value, options)
+                # f = 1 | "-01.999..e-1"
+                test_decimal_parser(T, 1, "-" * insertchar(base_str * "e-1", 3, "."); expect=-expected_value, options)
+                # f = 1 | "-019.99..e-2"
+                test_decimal_parser(T, 1, "-" * insertchar(base_str * "e-2", 4, "."); expect=-expected_value, options)
+            end
+        end
+        test_decimal_parser(T, 0, ".5"; expect=0, options)
+        test_decimal_parser(T, 0, "0"; expect=0, options)
+        test_decimal_parser(T, 0, "1"; expect=1, options)
+    end
+end;
+
+@testset "RoundingMode{:Throw} " begin
+    options = OPTIONS_THROWS
+    @testset "$T" for T in IntegerTypes
+        for (base_str, expected_value) in [
+           ("0.000", 0),
+           ("0.100", 1),
+           ("9.100e0", 91),
+           ("0.900" * ("0" ^ 99), 9),
+        ]
+            test_decimal_parser(T, 1, base_str; expect=expected_value, options)
+            if typemin(T) < 0
+                test_decimal_parser(T, 1, "-" * base_str; expect=-expected_value, options)
+            end
+        end
+        for base_str in [
+            ("0.0100"),
+            ("0.0001"),
+            ("0.000" * ("0" ^ 99) * "1"),
+            ("1.000" * ("0" ^ 99) * "1"),
+         ]
+            test_decimal_parser(T, 1, base_str; ok=false, inexact=true, options)
+            if typemin(T) < 0
+                test_decimal_parser(T, 1, "-" * base_str; ok=false, inexact=true, options)
+            end
+        end
+    end
+end
+
+@testset "invalid" begin
+    @testset "$T" for T in IntegerTypes
+        for base_str in [
+                "",
+                "a",
+                ";",
+                # ".",
+                "e",
+                "E",
+                ",0",
+                "10,",
+                "10,,0",
+                "10,,",
+                "10,.",
+                "e0",
+                "E0",
+                # ".e0",
+                # ".E0",
+                "10ea",
+                "10,e0",
+            ]
+
+            test_decimal_parser(T, 1, base_str, ok=false)
+            test_decimal_parser(T, 1, "+" * base_str, ok=false)
+            test_decimal_parser(T, 1, "-" * base_str, ok=false)
+        end
+    end
+    @test Parsers.invalid(Parsers.xparse(FixedDecimal{T,f}, "10.0,0"; groupmark=GROUP, delim=DELIM, decimal=DECIM, quoted=true).code)
+    @test Parsers.invalid(Parsers.xparse(FixedDecimal{T,f}, "10.0e1.0"; groupmark=GROUP, delim=DELIM, decimal=DECIM, quoted=true).code)
+    @test Parsers.invalid(Parsers.xparse(FixedDecimal{T,f}, "10,e0"; groupmark=GROUP, delim=DELIM, decimal=DECIM, quoted=true).code)
+end
+
+
+@testset "overflow" begin
+    @testset "typemax" begin
+        @testset "$T" for T in IntegerTypes
+            one_past_max = BigInt(typemax(T)) + 1
+            @testset "$f" for f in 0:(_maxintdigits(T) - 1)
+                f_comp = (_maxintdigits(T) - f)
+                for test_case in [
+                        # f = 2, T = Int8 | "1.28"
+                        insertchar("$one_past_max", f_comp+1, "."),
+                        # f = 2, T = Int8 | "01.28"
+                        "0" * insertchar("$one_past_max", f_comp+1, "."),
+                        # f = 2, T = Int8 | "1.28e0"
+                        insertchar("$one_past_max", f_comp+1, ".") * "e0",
+                        # f = 2, T = Int8 | "0.00128e+3"
+                        "0." * "0" ^ (f) * "$one_past_max" * "e+$(_maxintdigits(T))",
+                        # f = 2, T = Int8 | "12800e-4"
+                        "$one_past_max" * "0" ^ f * "e-$(2f)",
+                    ]
+                    test_decimal_parser(T, f, test_case, ok=false)
+                    test_decimal_parser(T, f, "+" * test_case, ok=false)
+                end
+            end
+        end
+    end
+
+    @testset "typemin" begin
+        @testset "$T" for T in IntegerTypes
+            abs_one_under_min = lpad(string(abs(BigInt(typemin(T)) - 1)), _maxintdigits(T), "0")
+            @testset "$f" for f in 0:(_maxintdigits(T) - 1)
+                f_comp = (_maxintdigits(T) - f)
+                for test_case in [
+                        # f = 2, T = Int8 | "1.29"
+                        insertchar("$abs_one_under_min", f_comp+1, "."),
+                        # f = 2, T = Int8 | "01.29"
+                        "0" * insertchar("$abs_one_under_min", f_comp+1, "."),
+                        # f = 2, T = Int8 | "1.29e0"
+                        insertchar("$abs_one_under_min", f_comp+1, ".") * "e0",
+                        # f = 2, T = Int8 | "0.00129e+3"
+                        "0." * "0" ^ (f) * "$abs_one_under_min" * "e+$(_maxintdigits(T))",
+                        # f = 2, T = Int8 | "12900e-4"
+                        "$abs_one_under_min" * "0" ^ f * "e-$(2f)",
+                    ]
+                    test_decimal_parser(T, f, "-" * test_case, ok=false)
+                end
+            end
+        end
+    end
+end
+
+@testset "misc" begin
+    @testset "$T negative zero" for T in UnsignedIntegerTypes
+        test_decimal_parser(T, 2, "-0.0000000", expect=0)
+    end
+
+    @testset "$T groupmarks" for T in IntegerTypes
+        test_decimal_parser(T, 2, "1,2,7.0e-2", expect=127)
+        test_decimal_parser(T, 2, "12,7.0e-2", expect=127)
+        test_decimal_parser(T, 2, "1,27.0e-2", expect=127)
+    end
+
+    @test Parsers.xparse(FixedDecimal{Int,8}, "2", groupmark=',', delim=',', decimal='.', quoted=true).val == FixedDecimal{Int,8}(2)
+    @test Parsers.xparse(FixedDecimal{Int,8}, "\" 2000.0 \"", groupmark=',', delim=',', decimal='.', quoted=true).val == FixedDecimal{Int,8}(2000)
+    @test Parsers.xparse(FixedDecimal{Int,8}, "\" 2,000.0 \"", groupmark=',', delim=',', decimal='.', quoted=true).val == FixedDecimal{Int,8}(2000)
+end
+
+@testset "misc options" begin
+    for (dec, grp, del) in (('.', "", ','), (',', " ", ';'), ('.', ",", '|'))
+        test_options = Parsers.Options(groupmark=isempty(grp) ? nothing : only(grp), decimal=dec, delim=del, quoted=true, rounding=RoundNearest)
+        for T in IntegerTypes
+            for test_case in [
+                    "123$(dec)123",
+                    "123$(dec)123$(del)",
+                    "1$(grp)2$(grp)3$(dec)123",
+                    "1$(grp)2$(grp)3$(grp)1$(grp)2$(grp)3e-3$(del)",
+                ]
+                test_decimal_parser(T, 0, test_case, expect=123, options=test_options)
+                test_decimal_parser(T, 0, "+" * test_case, expect=123, options=test_options)
+                if typemin(T) < 0
+                    test_decimal_parser(T, 0, "-" * test_case, expect=-123, options=test_options)
+                end
+            end
+        end
+    end
+end
+end # @testset "parse"

--- a/test/parse_tests.jl
+++ b/test/parse_tests.jl
@@ -95,7 +95,7 @@ end
 
 T = Int64
 f = 8
-@testset "parse" begin
+@testset "xparse" begin
 @testset "1.0" begin
     @testset "$T" for T in IntegerTypes
         @testset "$f" for f in 0:(_maxintdigits(T) - 1)
@@ -425,4 +425,260 @@ end
         end
     end
 end
-end # @testset "parse"
+end # @testset "xparse"
+
+
+@testset "parse" begin
+    # Note: the underscore used in the reinterpreted integer is used to indicate the decimal
+    # place.
+    @testset "decimal position" begin
+        @test parse(FD2, "123")   == reinterpret(FD2, 123_00)
+        @test parse(FD2, "0.123") == reinterpret(FD2, 0_12)
+        @test parse(FD2, ".123")  == reinterpret(FD2, 0_12)
+        @test parse(FD2, "1.23")  == reinterpret(FD2, 1_23)
+        @test parse(FD2, "12.3")  == reinterpret(FD2, 12_30)
+        @test parse(FD2, "123.")  == reinterpret(FD2, 123_00)
+        @test parse(FD2, "123.0") == reinterpret(FD2, 123_00)
+
+        @test parse(FD2, "-123")   == reinterpret(FD2, -123_00)
+        @test parse(FD2, "-0.123") == reinterpret(FD2, -0_12)
+        @test parse(FD2, "-.123")  == reinterpret(FD2, -0_12)
+        @test parse(FD2, "-1.23")  == reinterpret(FD2, -1_23)
+        @test parse(FD2, "-12.3")  == reinterpret(FD2, -12_30)
+        @test parse(FD2, "-123.")  == reinterpret(FD2, -123_00)
+        @test parse(FD2, "-123.0") == reinterpret(FD2, -123_00)
+    end
+
+    @testset "scientific notation" begin
+        @test parse(FD4, "12e0")   == reinterpret(FD4, 00012_0000)
+        @test parse(FD4, "12e3")   == reinterpret(FD4, 12000_0000)
+        @test parse(FD4, "12e-3")  == reinterpret(FD4, 00000_0120)
+        @test parse(FD4, "1.2e0")  == reinterpret(FD4, 00001_2000)
+        @test parse(FD4, "1.2e3")  == reinterpret(FD4, 01200_0000)
+        @test parse(FD4, "1.2e-3") == reinterpret(FD4, 00000_0012)
+        @test parse(FD4, "1.2e-4") == reinterpret(FD4, 00000_0001)
+
+        @test parse(FD4, "-12e0")   == reinterpret(FD4, -00012_0000)
+        @test parse(FD4, "-12e3")   == reinterpret(FD4, -12000_0000)
+        @test parse(FD4, "-12e-3")  == reinterpret(FD4, -00000_0120)
+        @test parse(FD4, "-1.2e0")  == reinterpret(FD4, -00001_2000)
+        @test parse(FD4, "-1.2e3")  == reinterpret(FD4, -01200_0000)
+        @test parse(FD4, "-1.2e-3") == reinterpret(FD4, -00000_0012)
+
+        @test parse(FD2, "999e-1") == reinterpret(FD2, 99_90)
+        @test parse(FD2, "999e-2") == reinterpret(FD2, 09_99)
+        @test parse(FD2, "999e-3") == reinterpret(FD2, 01_00)
+        @test parse(FD2, "999e-4") == reinterpret(FD2, 00_10)
+        @test parse(FD2, "999e-5") == reinterpret(FD2, 00_01)
+        @test parse(FD2, "999e-6") == reinterpret(FD2, 00_00)
+
+        @test parse(FD2, "-999e-1") == reinterpret(FD2, -99_90)
+        @test parse(FD2, "-999e-2") == reinterpret(FD2, -09_99)
+        @test parse(FD2, "-999e-3") == reinterpret(FD2, -01_00)
+        @test parse(FD2, "-999e-4") == reinterpret(FD2, -00_10)
+        @test parse(FD2, "-999e-5") == reinterpret(FD2, -00_01)
+        @test parse(FD2, "-999e-6") == reinterpret(FD2, -00_00)
+
+        @test parse(FD4, "9"^96 * "e-100") == reinterpret(FD4, 0_001)
+    end
+
+    @testset "round to nearest" begin
+        @test parse(FD2, "0.444") == reinterpret(FD2, 0_44)
+        @test parse(FD2, "0.445") == reinterpret(FD2, 0_44)
+        @test parse(FD2, "0.446") == reinterpret(FD2, 0_45)
+        @test parse(FD2, "0.454") == reinterpret(FD2, 0_45)
+        @test parse(FD2, "0.455") == reinterpret(FD2, 0_46)
+        @test parse(FD2, "0.456") == reinterpret(FD2, 0_46)
+
+        @test parse(FD2, "-0.444") == reinterpret(FD2, -0_44)
+        @test parse(FD2, "-0.445") == reinterpret(FD2, -0_44)
+        @test parse(FD2, "-0.446") == reinterpret(FD2, -0_45)
+        @test parse(FD2, "-0.454") == reinterpret(FD2, -0_45)
+        @test parse(FD2, "-0.455") == reinterpret(FD2, -0_46)
+        @test parse(FD2, "-0.456") == reinterpret(FD2, -0_46)
+
+        @test parse(FD2, "0.009")  == reinterpret(FD2,  0_01)
+        @test parse(FD2, "-0.009") == reinterpret(FD2, -0_01)
+
+        @test parse(FD4, "1.5e-4") == reinterpret(FD4, 0_0002)
+    end
+
+    @testset "round to zero" begin
+        @test parse(FD2, "0.444", RoundToZero) == reinterpret(FD2, 0_44)
+        @test parse(FD2, "0.445", RoundToZero) == reinterpret(FD2, 0_44)
+        @test parse(FD2, "0.446", RoundToZero) == reinterpret(FD2, 0_44)
+        @test parse(FD2, "0.454", RoundToZero) == reinterpret(FD2, 0_45)
+        @test parse(FD2, "0.455", RoundToZero) == reinterpret(FD2, 0_45)
+        @test parse(FD2, "0.456", RoundToZero) == reinterpret(FD2, 0_45)
+
+        @test parse(FD2, "-0.444", RoundToZero) == reinterpret(FD2, -0_44)
+        @test parse(FD2, "-0.445", RoundToZero) == reinterpret(FD2, -0_44)
+        @test parse(FD2, "-0.446", RoundToZero) == reinterpret(FD2, -0_44)
+        @test parse(FD2, "-0.454", RoundToZero) == reinterpret(FD2, -0_45)
+        @test parse(FD2, "-0.455", RoundToZero) == reinterpret(FD2, -0_45)
+        @test parse(FD2, "-0.456", RoundToZero) == reinterpret(FD2, -0_45)
+
+        @test parse(FD2, "0.009", RoundToZero)  == reinterpret(FD2, 0_00)
+        @test parse(FD2, "-0.009", RoundToZero) == reinterpret(FD2, 0_00)
+
+        @test parse(FD4, "1.5e-4", RoundToZero) == reinterpret(FD4, 0_0001)
+    end
+
+    @testset "round throws" begin
+        @test parse(FD2, "0.44", RoundThrows)  == reinterpret(FD2, 0_44)
+        @test parse(FD2, "0.440", RoundThrows) == reinterpret(FD2, 0_44)
+
+        @test_throws InexactError parse(FD2, "0.444", RoundThrows)
+        @test_throws InexactError parse(FD2, "0.445", RoundThrows)
+        @test_throws InexactError parse(FD2, "0.446", RoundThrows)
+        @test_throws InexactError parse(FD2, "0.454", RoundThrows)
+        @test_throws InexactError parse(FD2, "0.455", RoundThrows)
+        @test_throws InexactError parse(FD2, "0.456", RoundThrows)
+
+        @test_throws InexactError parse(FD2, "-0.444", RoundThrows)
+        @test_throws InexactError parse(FD2, "-0.445", RoundThrows)
+        @test_throws InexactError parse(FD2, "-0.446", RoundThrows)
+        @test_throws InexactError parse(FD2, "-0.454", RoundThrows)
+        @test_throws InexactError parse(FD2, "-0.455", RoundThrows)
+        @test_throws InexactError parse(FD2, "-0.456", RoundThrows)
+
+        @test_throws InexactError parse(FD2, "0.009", RoundThrows)
+        @test_throws InexactError parse(FD2, "-0.009", RoundThrows)
+        @test_throws InexactError parse(FD4, "1.5e-4", RoundThrows)
+    end
+
+    @testset "invalid" begin
+        @test_throws OverflowError parse(FD4, "1.2e100")
+        @test_throws ArgumentError parse(FD4, "foo")
+        @test_throws ArgumentError parse(FD4, "1.2.3")
+        @test_throws ArgumentError parse(FD4, "1.2", RoundUp)
+    end
+end
+
+
+@testset "tryparse" begin
+    # Note: the underscore used in the reinterpreted integer is used to indicate the decimal
+    # place.
+    @testset "decimal position" begin
+        @test tryparse(FD2, "123")   == reinterpret(FD2, 123_00)
+        @test tryparse(FD2, "0.123") == reinterpret(FD2, 0_12)
+        @test tryparse(FD2, ".123")  == reinterpret(FD2, 0_12)
+        @test tryparse(FD2, "1.23")  == reinterpret(FD2, 1_23)
+        @test tryparse(FD2, "12.3")  == reinterpret(FD2, 12_30)
+        @test tryparse(FD2, "123.")  == reinterpret(FD2, 123_00)
+        @test tryparse(FD2, "123.0") == reinterpret(FD2, 123_00)
+
+        @test tryparse(FD2, "-123")   == reinterpret(FD2, -123_00)
+        @test tryparse(FD2, "-0.123") == reinterpret(FD2, -0_12)
+        @test tryparse(FD2, "-.123")  == reinterpret(FD2, -0_12)
+        @test tryparse(FD2, "-1.23")  == reinterpret(FD2, -1_23)
+        @test tryparse(FD2, "-12.3")  == reinterpret(FD2, -12_30)
+        @test tryparse(FD2, "-123.")  == reinterpret(FD2, -123_00)
+        @test tryparse(FD2, "-123.0") == reinterpret(FD2, -123_00)
+    end
+
+    @testset "scientific notation" begin
+        @test tryparse(FD4, "12e0")   == reinterpret(FD4, 00012_0000)
+        @test tryparse(FD4, "12e3")   == reinterpret(FD4, 12000_0000)
+        @test tryparse(FD4, "12e-3")  == reinterpret(FD4, 00000_0120)
+        @test tryparse(FD4, "1.2e0")  == reinterpret(FD4, 00001_2000)
+        @test tryparse(FD4, "1.2e3")  == reinterpret(FD4, 01200_0000)
+        @test tryparse(FD4, "1.2e-3") == reinterpret(FD4, 00000_0012)
+        @test tryparse(FD4, "1.2e-4") == reinterpret(FD4, 00000_0001)
+
+        @test tryparse(FD4, "-12e0")   == reinterpret(FD4, -00012_0000)
+        @test tryparse(FD4, "-12e3")   == reinterpret(FD4, -12000_0000)
+        @test tryparse(FD4, "-12e-3")  == reinterpret(FD4, -00000_0120)
+        @test tryparse(FD4, "-1.2e0")  == reinterpret(FD4, -00001_2000)
+        @test tryparse(FD4, "-1.2e3")  == reinterpret(FD4, -01200_0000)
+        @test tryparse(FD4, "-1.2e-3") == reinterpret(FD4, -00000_0012)
+
+        @test tryparse(FD2, "999e-1") == reinterpret(FD2, 99_90)
+        @test tryparse(FD2, "999e-2") == reinterpret(FD2, 09_99)
+        @test tryparse(FD2, "999e-3") == reinterpret(FD2, 01_00)
+        @test tryparse(FD2, "999e-4") == reinterpret(FD2, 00_10)
+        @test tryparse(FD2, "999e-5") == reinterpret(FD2, 00_01)
+        @test tryparse(FD2, "999e-6") == reinterpret(FD2, 00_00)
+
+        @test tryparse(FD2, "-999e-1") == reinterpret(FD2, -99_90)
+        @test tryparse(FD2, "-999e-2") == reinterpret(FD2, -09_99)
+        @test tryparse(FD2, "-999e-3") == reinterpret(FD2, -01_00)
+        @test tryparse(FD2, "-999e-4") == reinterpret(FD2, -00_10)
+        @test tryparse(FD2, "-999e-5") == reinterpret(FD2, -00_01)
+        @test tryparse(FD2, "-999e-6") == reinterpret(FD2, -00_00)
+
+        @test tryparse(FD4, "9"^96 * "e-100") == reinterpret(FD4, 0_001)
+    end
+
+    @testset "round to nearest" begin
+        @test tryparse(FD2, "0.444") == reinterpret(FD2, 0_44)
+        @test tryparse(FD2, "0.445") == reinterpret(FD2, 0_44)
+        @test tryparse(FD2, "0.446") == reinterpret(FD2, 0_45)
+        @test tryparse(FD2, "0.454") == reinterpret(FD2, 0_45)
+        @test tryparse(FD2, "0.455") == reinterpret(FD2, 0_46)
+        @test tryparse(FD2, "0.456") == reinterpret(FD2, 0_46)
+
+        @test tryparse(FD2, "-0.444") == reinterpret(FD2, -0_44)
+        @test tryparse(FD2, "-0.445") == reinterpret(FD2, -0_44)
+        @test tryparse(FD2, "-0.446") == reinterpret(FD2, -0_45)
+        @test tryparse(FD2, "-0.454") == reinterpret(FD2, -0_45)
+        @test tryparse(FD2, "-0.455") == reinterpret(FD2, -0_46)
+        @test tryparse(FD2, "-0.456") == reinterpret(FD2, -0_46)
+
+        @test tryparse(FD2, "0.009")  == reinterpret(FD2,  0_01)
+        @test tryparse(FD2, "-0.009") == reinterpret(FD2, -0_01)
+
+        @test tryparse(FD4, "1.5e-4") == reinterpret(FD4, 0_0002)
+    end
+
+    @testset "round to zero" begin
+        @test tryparse(FD2, "0.444", RoundToZero) == reinterpret(FD2, 0_44)
+        @test tryparse(FD2, "0.445", RoundToZero) == reinterpret(FD2, 0_44)
+        @test tryparse(FD2, "0.446", RoundToZero) == reinterpret(FD2, 0_44)
+        @test tryparse(FD2, "0.454", RoundToZero) == reinterpret(FD2, 0_45)
+        @test tryparse(FD2, "0.455", RoundToZero) == reinterpret(FD2, 0_45)
+        @test tryparse(FD2, "0.456", RoundToZero) == reinterpret(FD2, 0_45)
+
+        @test tryparse(FD2, "-0.444", RoundToZero) == reinterpret(FD2, -0_44)
+        @test tryparse(FD2, "-0.445", RoundToZero) == reinterpret(FD2, -0_44)
+        @test tryparse(FD2, "-0.446", RoundToZero) == reinterpret(FD2, -0_44)
+        @test tryparse(FD2, "-0.454", RoundToZero) == reinterpret(FD2, -0_45)
+        @test tryparse(FD2, "-0.455", RoundToZero) == reinterpret(FD2, -0_45)
+        @test tryparse(FD2, "-0.456", RoundToZero) == reinterpret(FD2, -0_45)
+
+        @test tryparse(FD2, "0.009", RoundToZero)  == reinterpret(FD2, 0_00)
+        @test tryparse(FD2, "-0.009", RoundToZero) == reinterpret(FD2, 0_00)
+
+        @test tryparse(FD4, "1.5e-4", RoundToZero) == reinterpret(FD4, 0_0001)
+    end
+
+    @testset "round throws" begin
+        @test tryparse(FD2, "0.44", RoundThrows)  == reinterpret(FD2, 0_44)
+        @test tryparse(FD2, "0.440", RoundThrows) == reinterpret(FD2, 0_44)
+
+        @test isnothing(tryparse(FD2, "0.444", RoundThrows))
+        @test isnothing(tryparse(FD2, "0.445", RoundThrows))
+        @test isnothing(tryparse(FD2, "0.446", RoundThrows))
+        @test isnothing(tryparse(FD2, "0.454", RoundThrows))
+        @test isnothing(tryparse(FD2, "0.455", RoundThrows))
+        @test isnothing(tryparse(FD2, "0.456", RoundThrows))
+
+        @test isnothing(tryparse(FD2, "-0.444", RoundThrows))
+        @test isnothing(tryparse(FD2, "-0.445", RoundThrows))
+        @test isnothing(tryparse(FD2, "-0.446", RoundThrows))
+        @test isnothing(tryparse(FD2, "-0.454", RoundThrows))
+        @test isnothing(tryparse(FD2, "-0.455", RoundThrows))
+        @test isnothing(tryparse(FD2, "-0.456", RoundThrows))
+
+        @test isnothing(tryparse(FD2, "0.009", RoundThrows))
+        @test isnothing(tryparse(FD2, "-0.009", RoundThrows))
+        @test isnothing(tryparse(FD4, "1.5e-4", RoundThrows))
+    end
+
+    @testset "invalid" begin
+        @test isnothing(tryparse(FD4, "1.2e100"))
+        @test isnothing(tryparse(FD4, "foo"))
+        @test isnothing(tryparse(FD4, "1.2.3"))
+        @test isnothing(tryparse(FD4, "1.2", RoundUp))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -943,147 +943,20 @@ end
     end
 end
 
-@testset "xparse" begin
+@testset "parsing" begin
     @time include(joinpath(pkg_path, "test", "parse_tests.jl"))
 end
 
-@testset "parse" begin
-    # Note: the underscore used in the reinterpreted integer is used to indicate the decimal
-    # place.
-    @testset "decimal position" begin
-        @test parse(FD2, "123")   == reinterpret(FD2, 123_00)
-        @test parse(FD2, "0.123") == reinterpret(FD2, 0_12)
-        @test parse(FD2, ".123")  == reinterpret(FD2, 0_12)
-        @test parse(FD2, "1.23")  == reinterpret(FD2, 1_23)
-        @test parse(FD2, "12.3")  == reinterpret(FD2, 12_30)
-        @test parse(FD2, "123.")  == reinterpret(FD2, 123_00)
-        @test parse(FD2, "123.0") == reinterpret(FD2, 123_00)
+@testset "hashing" begin
+    fd1 = FixedDecimal{Int, 4}(2.5)
+    fd2 = FixedDecimal{Int, 5}(2.5)
+    fd3 = FixedDecimal{Int, 4}(3.5)
 
-        @test parse(FD2, "-123")   == reinterpret(FD2, -123_00)
-        @test parse(FD2, "-0.123") == reinterpret(FD2, -0_12)
-        @test parse(FD2, "-.123")  == reinterpret(FD2, -0_12)
-        @test parse(FD2, "-1.23")  == reinterpret(FD2, -1_23)
-        @test parse(FD2, "-12.3")  == reinterpret(FD2, -12_30)
-        @test parse(FD2, "-123.")  == reinterpret(FD2, -123_00)
-        @test parse(FD2, "-123.0") == reinterpret(FD2, -123_00)
-    end
-
-    @testset "scientific notation" begin
-        @test parse(FD4, "12e0")   == reinterpret(FD4, 00012_0000)
-        @test parse(FD4, "12e3")   == reinterpret(FD4, 12000_0000)
-        @test parse(FD4, "12e-3")  == reinterpret(FD4, 00000_0120)
-        @test parse(FD4, "1.2e0")  == reinterpret(FD4, 00001_2000)
-        @test parse(FD4, "1.2e3")  == reinterpret(FD4, 01200_0000)
-        @test parse(FD4, "1.2e-3") == reinterpret(FD4, 00000_0012)
-        @test parse(FD4, "1.2e-4") == reinterpret(FD4, 00000_0001)
-
-        @test parse(FD4, "-12e0")   == reinterpret(FD4, -00012_0000)
-        @test parse(FD4, "-12e3")   == reinterpret(FD4, -12000_0000)
-        @test parse(FD4, "-12e-3")  == reinterpret(FD4, -00000_0120)
-        @test parse(FD4, "-1.2e0")  == reinterpret(FD4, -00001_2000)
-        @test parse(FD4, "-1.2e3")  == reinterpret(FD4, -01200_0000)
-        @test parse(FD4, "-1.2e-3") == reinterpret(FD4, -00000_0012)
-
-        @test parse(FD2, "999e-1") == reinterpret(FD2, 99_90)
-        @test parse(FD2, "999e-2") == reinterpret(FD2, 09_99)
-        @test parse(FD2, "999e-3") == reinterpret(FD2, 01_00)
-        @test parse(FD2, "999e-4") == reinterpret(FD2, 00_10)
-        @test parse(FD2, "999e-5") == reinterpret(FD2, 00_01)
-        @test parse(FD2, "999e-6") == reinterpret(FD2, 00_00)
-
-        @test parse(FD2, "-999e-1") == reinterpret(FD2, -99_90)
-        @test parse(FD2, "-999e-2") == reinterpret(FD2, -09_99)
-        @test parse(FD2, "-999e-3") == reinterpret(FD2, -01_00)
-        @test parse(FD2, "-999e-4") == reinterpret(FD2, -00_10)
-        @test parse(FD2, "-999e-5") == reinterpret(FD2, -00_01)
-        @test parse(FD2, "-999e-6") == reinterpret(FD2, -00_00)
-
-        @test parse(FD4, "9"^96 * "e-100") == reinterpret(FD4, 0_001)
-    end
-
-    @testset "round to nearest" begin
-        @test parse(FD2, "0.444") == reinterpret(FD2, 0_44)
-        @test parse(FD2, "0.445") == reinterpret(FD2, 0_44)
-        @test parse(FD2, "0.446") == reinterpret(FD2, 0_45)
-        @test parse(FD2, "0.454") == reinterpret(FD2, 0_45)
-        @test parse(FD2, "0.455") == reinterpret(FD2, 0_46)
-        @test parse(FD2, "0.456") == reinterpret(FD2, 0_46)
-
-        @test parse(FD2, "-0.444") == reinterpret(FD2, -0_44)
-        @test parse(FD2, "-0.445") == reinterpret(FD2, -0_44)
-        @test parse(FD2, "-0.446") == reinterpret(FD2, -0_45)
-        @test parse(FD2, "-0.454") == reinterpret(FD2, -0_45)
-        @test parse(FD2, "-0.455") == reinterpret(FD2, -0_46)
-        @test parse(FD2, "-0.456") == reinterpret(FD2, -0_46)
-
-        @test parse(FD2, "0.009")  == reinterpret(FD2,  0_01)
-        @test parse(FD2, "-0.009") == reinterpret(FD2, -0_01)
-
-        @test parse(FD4, "1.5e-4") == reinterpret(FD4, 0_0002)
-    end
-
-    @testset "round to zero" begin
-        @test parse(FD2, "0.444", RoundToZero) == reinterpret(FD2, 0_44)
-        @test parse(FD2, "0.445", RoundToZero) == reinterpret(FD2, 0_44)
-        @test parse(FD2, "0.446", RoundToZero) == reinterpret(FD2, 0_44)
-        @test parse(FD2, "0.454", RoundToZero) == reinterpret(FD2, 0_45)
-        @test parse(FD2, "0.455", RoundToZero) == reinterpret(FD2, 0_45)
-        @test parse(FD2, "0.456", RoundToZero) == reinterpret(FD2, 0_45)
-
-        @test parse(FD2, "-0.444", RoundToZero) == reinterpret(FD2, -0_44)
-        @test parse(FD2, "-0.445", RoundToZero) == reinterpret(FD2, -0_44)
-        @test parse(FD2, "-0.446", RoundToZero) == reinterpret(FD2, -0_44)
-        @test parse(FD2, "-0.454", RoundToZero) == reinterpret(FD2, -0_45)
-        @test parse(FD2, "-0.455", RoundToZero) == reinterpret(FD2, -0_45)
-        @test parse(FD2, "-0.456", RoundToZero) == reinterpret(FD2, -0_45)
-
-        @test parse(FD2, "0.009", RoundToZero)  == reinterpret(FD2, 0_00)
-        @test parse(FD2, "-0.009", RoundToZero) == reinterpret(FD2, 0_00)
-
-        @test parse(FD4, "1.5e-4", RoundToZero) == reinterpret(FD4, 0_0001)
-    end
-
-    @testset "round throws" begin
-        @test parse(FD2, "0.44", RoundThrows)  == reinterpret(FD2, 0_44)
-        @test parse(FD2, "0.440", RoundThrows) == reinterpret(FD2, 0_44)
-
-        @test_throws InexactError parse(FD2, "0.444", RoundThrows)
-        @test_throws InexactError parse(FD2, "0.445", RoundThrows)
-        @test_throws InexactError parse(FD2, "0.446", RoundThrows)
-        @test_throws InexactError parse(FD2, "0.454", RoundThrows)
-        @test_throws InexactError parse(FD2, "0.455", RoundThrows)
-        @test_throws InexactError parse(FD2, "0.456", RoundThrows)
-
-        @test_throws InexactError parse(FD2, "-0.444", RoundThrows)
-        @test_throws InexactError parse(FD2, "-0.445", RoundThrows)
-        @test_throws InexactError parse(FD2, "-0.446", RoundThrows)
-        @test_throws InexactError parse(FD2, "-0.454", RoundThrows)
-        @test_throws InexactError parse(FD2, "-0.455", RoundThrows)
-        @test_throws InexactError parse(FD2, "-0.456", RoundThrows)
-
-        @test_throws InexactError parse(FD2, "0.009", RoundThrows)
-        @test_throws InexactError parse(FD2, "-0.009", RoundThrows)
-        @test_throws InexactError parse(FD4, "1.5e-4", RoundThrows)
-    end
-
-    @testset "invalid" begin
-        @test_throws OverflowError parse(FD4, "1.2e100")
-        @test_throws ArgumentError parse(FD4, "foo")
-        @test_throws ArgumentError parse(FD4, "1.2.3")
-        @test_throws ArgumentError parse(FD4, "1.2", RoundUp)
-    end
-
-    @testset "hashing" begin
-        fd1 = FixedDecimal{Int, 4}(2.5)
-        fd2 = FixedDecimal{Int, 5}(2.5)
-        fd3 = FixedDecimal{Int, 4}(3.5)
-
-        @test hash(fd1) == hash(fd2)
-        @test hash(fd1) != hash(fd3)
-        @test hash(fd1) != hash(fd1.i)
-        @test hash(FD2(1//10)) == hash(1//10)
-        @test hash(FD2(1//10)) ≠ hash(0.1)
-    end
+    @test hash(fd1) == hash(fd2)
+    @test hash(fd1) != hash(fd3)
+    @test hash(fd1) != hash(fd1.i)
+    @test hash(FD2(1//10)) == hash(1//10)
+    @test hash(FD2(1//10)) ≠ hash(0.1)
 end
 
 end  # global testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,8 +3,10 @@ using FixedPointDecimals: FD, value
 using Test
 using Printf
 using Base.Checked: checked_mul
+using Parsers
 
-include("utils.jl")
+pkg_path = pkgdir(FixedPointDecimals)
+include(joinpath(pkg_path, "test", "utils.jl"))
 
 const SFD2 = FixedDecimal{Int16, 2}
 const SFD4 = FixedDecimal{Int16, 4}
@@ -605,7 +607,7 @@ end
         @test round(Int, FD2(1.50)) === 2
     end
 
-    # Is alias for `ceil`. 
+    # Is alias for `ceil`.
     @testset "up" begin
         @test round(Int, FD2(-0.51), RoundUp) === 0
         @test round(Int, FD2(-0.50), RoundUp) === 0
@@ -615,7 +617,7 @@ end
         @test round(Int, FD2(1.50), RoundUp) === 2
     end
 
-    # Is alias for `floor`. 
+    # Is alias for `floor`.
     @testset "down" begin
         @test round(Int, FD2(-0.51), RoundDown) === -1
         @test round(Int, FD2(-0.50), RoundDown) === -1
@@ -625,12 +627,12 @@ end
         @test round(Int, FD2(1.50), RoundDown) === 1
     end
 
-    # Is alias for `trunc`. 
+    # Is alias for `trunc`.
     @testset "to zero" begin
         @test round(Int, FD2(-0.51), RoundToZero) === 0
         @test round(Int, FD2(-0.50), RoundToZero) === 0
         @test round(Int, FD2(-0.49), RoundToZero) === 0
-        @test round(Int, FD2(0.50), RoundToZero) === 0 
+        @test round(Int, FD2(0.50), RoundToZero) === 0
         @test round(Int, FD2(0.51), RoundToZero) === 0
         @test round(Int, FD2(1.50), RoundToZero) === 1
     end
@@ -941,16 +943,8 @@ end
     end
 end
 
-@testset "parse_round" begin
-    @test FixedPointDecimals.parse_round(Int, "44", RoundNearest) == 0
-    @test FixedPointDecimals.parse_round(Int, "45", RoundNearest) == 0
-    @test FixedPointDecimals.parse_round(Int, "46", RoundNearest) == 1
-    @test FixedPointDecimals.parse_round(Int, "54", RoundNearest) == 0
-    @test FixedPointDecimals.parse_round(Int, "55", RoundNearest) == 1
-    @test FixedPointDecimals.parse_round(Int, "56", RoundNearest) == 1
-
-    # Handle a number of digits that exceeds the storage capacity of Int128
-    @test FixedPointDecimals.parse_round(Int8, "9"^40, RoundNearest) == 1
+@testset "xparse" begin
+    @time include(joinpath(pkg_path, "test", "parse_tests.jl"))
 end
 
 @testset "parse" begin
@@ -1069,7 +1063,6 @@ end
 
         @test_throws InexactError parse(FD2, "0.009", RoundThrows)
         @test_throws InexactError parse(FD2, "-0.009", RoundThrows)
-
         @test_throws InexactError parse(FD4, "1.5e-4", RoundThrows)
     end
 


### PR DESCRIPTION
This hooks into the floating point parsing machinery from `Parsers.jl`, where we also accumulate all the digits and note the effective exponent before we do "scaling" -- for `FixedDecimals`, the scaling means padding the backing integer with zeros or rounding them as necessary. This change should improve performance noticeably as we no longer allocate any strings during parsing.

`RoundNearest` rounding was redone during parsing to match the rounding behaviors on already parsed integers.

cc: @quinnj @NHDaly 