### PR TITLE
Eliminate BigInt allocs for 128-bit FixedDecimal conversions.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -314,10 +314,32 @@ end
     end
 end
 @testset "128-bit conversion performance" begin
-    #@test Base.convert(WFD2, 1) == WFD2(1)
-    #@test @allocated(Base.convert(WFD2, 1)) == 0
-end
+    # Baseline cases
+    @test @allocated(Base.convert(FD2, Int8(-1))) == 0
+    @test @allocated(Base.convert(FD2, UInt8(1))) == 0
+    @test @allocated(Base.convert(SFD2, Int8(-1))) == 0
 
+    # Int 128 cases
+    @test @allocated(Base.convert(WFD2, 1)) == 0
+    @test @allocated(Base.convert(WFD2, 1)) == 0
+    @test @allocated(Base.convert(UWFD2, 1)) == 0
+    @test @allocated(Base.convert(WFD2, -1)) == 0
+    # @test @allocated(Base.convert(UWFD2, -1)) == 32   # not sure how best to test this
+    @test @allocated(Base.convert(WFD2, UInt(1))) == 0
+    @test @allocated(Base.convert(UWFD2, UInt(1))) == 0
+
+    @test @allocated(Base.convert(WFD2, Int128(1))) == 0
+    @test @allocated(Base.convert(UWFD2, Int128(1))) == 0
+    @test @allocated(Base.convert(WFD2, UInt128(1))) == 0
+    @test @allocated(Base.convert(UWFD2, UInt128(1))) == 0
+    @test @allocated(Base.convert(WFD2, Int128(-1))) == 0
+
+    @test @allocated(Base.convert(FD2, Int128(1))) == 0
+    @test @allocated(Base.convert(UFD2, Int128(1))) == 0
+    @test @allocated(Base.convert(FD2, UInt128(1))) == 0
+    @test @allocated(Base.convert(UFD2, UInt128(1))) == 0
+    @test @allocated(Base.convert(FD2, Int128(-1))) == 0
+end
 
 @testset "promotion" begin
     @test 1//10 + FD2(0.1) === 1//5


### PR DESCRIPTION
Before this PR, converting an Int to a FD{Int128} had to allocate a BigInt, which is fairly expensive:
```julia
julia> @time convert(FixedDecimal{Int128, 2}, 1)
  0.000003 seconds (7 allocations: 128 bytes)
FixedDecimal{Int128,2}(1.00)
```
After, the allocs are gone, and this is only involves the checks for overflow and the coefficient multiplication:
```julia
julia> @time convert(FixedDecimal{Int128, 2}, 1)
  0.000000 seconds
FixedDecimal{Int128,2}(1.00)
```

I've added tests to cover all corner cases and to ensure the allocations remain eliminated.

Also, while I was here, I have changed the InexactErrors you get for illegal conversions to be clearer, by reporting on the types involved in the conversion directly, rather than the internal errors you got previously:
```julia
Before: InexactError(:Int128, Int128, 34028236692093846346337460743176821145500)
 After: InexactError(:convert, FixedDecimal{Int128, 2}, 0xffffffffffffffffffffffffffffffff)

Before: InexactError: Int128(17014118346046923173168730371588410572700)
 After: InexactError: convert(FixedDecimal{Int128, 2}, 170141183460469231731687303715884105727)
```

Thanks!