### PR TITLE
Fix bug in previous PR for comparisons that underflow (large negatives)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FixedPointDecimals"
 uuid = "fb4d412d-6eee-574d-9565-ede6634db7b0"
 authors = ["Fengyang Wang <fengyang.wang.0@gmail.com>", "Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"

--- a/test/FixedDecimal.jl
+++ b/test/FixedDecimal.jl
@@ -327,6 +327,17 @@ end
     @test typemax(FD{Int8, 2}) <  typemax(FD{Int8,1})
     @test typemax(FD{Int8, 2}) <= typemax(FD{Int8,1})
 
+    @test !(typemin(FD{Int8, 2}) <= typemin(FD{Int8,1}))
+    @test !(typemin(FD{Int8, 1}) >= typemin(FD{Int8,2}))
+    @test !(typemin(FD{Int8, 1}) >  typemin(FD{Int8,2}))
+    @test !(typemin(FD{Int8, 1}) >= typemin(FD{Int8,2}))
+    @test !(typemin(FD{Int8, 2}) <  typemin(FD{Int8,1}))
+    @test !(typemin(FD{Int8, 2}) <= typemin(FD{Int8,1}))
+    @test !(typemax(FD{Int8, 1}) <  typemax(FD{Int8,2}))
+    @test !(typemax(FD{Int8, 1}) <= typemax(FD{Int8,2}))
+    @test !(typemax(FD{Int8, 2}) >  typemax(FD{Int8,1}))
+    @test !(typemax(FD{Int8, 2}) >= typemax(FD{Int8,1}))
+
     @testset "Integer and FD" begin
         @test 1 <= FD{Int8, 2}(1) <= 1
         @test 1 >= FD{Int8, 2}(1) >= 1

--- a/test/FixedDecimal.jl
+++ b/test/FixedDecimal.jl
@@ -297,6 +297,10 @@ end
     @test FD{Int8, 2}(0) != typemax(Int16)
     @test FD{Int8, 0}(0) != typemin(Int16)
     @test FD{Int8, 2}(0) != typemin(Int16)
+
+    # less precision allows smaller and bigger numbers
+    @test typemin(FD{Int8, 1}) != typemin(FD{Int8,2})
+    @test typemax(FD{Int8, 1}) != typemax(FD{Int8,2})
 end
 @testset "inequality between types" begin
     @test FD{Int8, 0}(1) <= FD{Int8, 2}(1)
@@ -312,41 +316,78 @@ end
     @test FD{Int8, 0}(4) >= FD{Int16, 4}(1)  # FD{Int16,4}(4) doesn't fit
     @test FD{Int16, 4}(1) < FD{Int8, 0}(4)  # FD{Int16,4}(4) doesn't fit
 
-    # Integer == FD
-    @test 1 <= FD{Int8, 2}(1) <= 1
-    @test 1 >= FD{Int8, 2}(1) >= 1
-    @test 2 > FD{Int8, 2}(1)
-    @test FD{Int8, 2}(1) < 2
-    @test 2 >= FD{Int8, 2}(1)
-    @test FD{Int8, 2}(1) <= 2
-    @test 1 <= FD{Int8, 0}(1) < 2
+    # less precision allows smaller numbers
+    @test typemin(FD{Int8, 1}) < typemin(FD{Int8,2})
+    @test typemin(FD{Int8, 1}) <= typemin(FD{Int8,2})
+    # less precision allows bigger numbers
+    @test typemax(FD{Int8, 1}) > typemax(FD{Int8,2})
+    @test typemax(FD{Int8, 1}) >= typemax(FD{Int8,2})
 
-    @test typemax(Int16) > FD{Int8, 0}(1) > typemin(Int16)
-    @test typemax(Int16) > FD{Int8, 2}(1) > typemin(Int16)
-    @test typemin(Int16) < FD{Int8, 0}(1) < typemax(Int16)
-    @test typemin(Int16) < FD{Int8, 2}(1) < typemax(Int16)
-    @test !(typemax(Int16) < FD{Int8, 0}(1) < typemin(Int16))
-    @test !(typemax(Int16) < FD{Int8, 2}(1) < typemin(Int16))
-    @test !(typemin(Int16) > FD{Int8, 0}(1) > typemax(Int16))
-    @test !(typemin(Int16) > FD{Int8, 2}(1) > typemax(Int16))
+    @testset "Integer and FD" begin
+        @test 1 <= FD{Int8, 2}(1) <= 1
+        @test 1 >= FD{Int8, 2}(1) >= 1
+        @test 2 > FD{Int8, 2}(1)
+        @test FD{Int8, 2}(1) < 2
+        @test 2 >= FD{Int8, 2}(1)
+        @test FD{Int8, 2}(1) <= 2
+        @test 1 <= FD{Int8, 0}(1) < 2
 
-    @test typemax(Int16) > FD{Int8, 0}(-1) > typemin(Int16)
-    @test typemax(Int16) > FD{Int8, 2}(-1) > typemin(Int16)
-    @test typemin(Int16) < FD{Int8, 0}(-1) < typemax(Int16)
-    @test typemin(Int16) < FD{Int8, 2}(-1) < typemax(Int16)
-    @test !(typemax(Int16) < FD{Int8, 0}(-1) < typemin(Int16))
-    @test !(typemax(Int16) < FD{Int8, 2}(-1) < typemin(Int16))
-    @test !(typemin(Int16) > FD{Int8, 0}(-1) > typemax(Int16))
-    @test !(typemin(Int16) > FD{Int8, 2}(-1) > typemax(Int16))
+        # negatives
+        @test -1 <= FD{Int8, 2}(-1) <= -1
+        @test -1 >= FD{Int8, 2}(-1) >= -1
+        @test -2 < FD{Int8, 2}(-1)
+        @test FD{Int8, 2}(-1) > -2
+        @test -2 <= FD{Int8, 2}(-1)
+        @test FD{Int8, 2}(-1) >= -2
+        @test -1 <= FD{Int8, 0}(-1) < 2
 
-    @test typemax(Int16) >= FD{Int8, 0}(0) >= typemin(Int16)
-    @test typemax(Int16) >= FD{Int8, 2}(0) >= typemin(Int16)
-    @test typemin(Int16) <= FD{Int8, 0}(0) <= typemax(Int16)
-    @test typemin(Int16) <= FD{Int8, 2}(0) <= typemax(Int16)
-    @test !(typemax(Int16) <= FD{Int8, 0}(-1) <= typemin(Int16))
-    @test !(typemax(Int16) <= FD{Int8, 2}(-1) <= typemin(Int16))
-    @test !(typemin(Int16) >= FD{Int8, 0}(-1) >= typemax(Int16))
-    @test !(typemin(Int16) >= FD{Int8, 2}(-1) >= typemax(Int16))
+        # Same types
+        @test typemax(Int8) > FD{Int8, 0}(1) > typemin(Int8)
+        @test typemax(Int8) > FD{Int8, 2}(1) > typemin(Int8)
+        @test typemin(Int8) < FD{Int8, 0}(1) < typemax(Int8)
+        @test typemin(Int8) < FD{Int8, 2}(1) < typemax(Int8)
+        @test !(typemax(Int8) < FD{Int8, 0}(1) < typemin(Int8))
+        @test !(typemax(Int8) < FD{Int8, 2}(1) < typemin(Int8))
+        @test !(typemin(Int8) > FD{Int8, 0}(1) > typemax(Int8))
+        @test !(typemin(Int8) > FD{Int8, 2}(1) > typemax(Int8))
+
+        @test typemax(Int8) > FD{Int8, 0}(-1) > typemin(Int8)
+        @test typemax(Int8) > FD{Int8, 2}(-1) > typemin(Int8)
+        @test typemin(Int8) < FD{Int8, 0}(-1) < typemax(Int8)
+        @test typemin(Int8) < FD{Int8, 2}(-1) < typemax(Int8)
+        @test !(typemax(Int8) < FD{Int8, 0}(-1) < typemin(Int8))
+        @test !(typemax(Int8) < FD{Int8, 2}(-1) < typemin(Int8))
+        @test !(typemin(Int8) > FD{Int8, 0}(-1) > typemax(Int8))
+        @test !(typemin(Int8) > FD{Int8, 2}(-1) > typemax(Int8))
+
+        # Different types
+        @test typemax(Int16) > FD{Int8, 0}(1) > typemin(Int16)
+        @test typemax(Int16) > FD{Int8, 2}(1) > typemin(Int16)
+        @test typemin(Int16) < FD{Int8, 0}(1) < typemax(Int16)
+        @test typemin(Int16) < FD{Int8, 2}(1) < typemax(Int16)
+        @test !(typemax(Int16) < FD{Int8, 0}(1) < typemin(Int16))
+        @test !(typemax(Int16) < FD{Int8, 2}(1) < typemin(Int16))
+        @test !(typemin(Int16) > FD{Int8, 0}(1) > typemax(Int16))
+        @test !(typemin(Int16) > FD{Int8, 2}(1) > typemax(Int16))
+
+        @test typemax(Int16) > FD{Int8, 0}(-1) > typemin(Int16)
+        @test typemax(Int16) > FD{Int8, 2}(-1) > typemin(Int16)
+        @test typemin(Int16) < FD{Int8, 0}(-1) < typemax(Int16)
+        @test typemin(Int16) < FD{Int8, 2}(-1) < typemax(Int16)
+        @test !(typemax(Int16) < FD{Int8, 0}(-1) < typemin(Int16))
+        @test !(typemax(Int16) < FD{Int8, 2}(-1) < typemin(Int16))
+        @test !(typemin(Int16) > FD{Int8, 0}(-1) > typemax(Int16))
+        @test !(typemin(Int16) > FD{Int8, 2}(-1) > typemax(Int16))
+
+        @test typemax(Int16) >= FD{Int8, 0}(0) >= typemin(Int16)
+        @test typemax(Int16) >= FD{Int8, 2}(0) >= typemin(Int16)
+        @test typemin(Int16) <= FD{Int8, 0}(0) <= typemax(Int16)
+        @test typemin(Int16) <= FD{Int8, 2}(0) <= typemax(Int16)
+        @test !(typemax(Int16) <= FD{Int8, 0}(-1) <= typemin(Int16))
+        @test !(typemax(Int16) <= FD{Int8, 2}(-1) <= typemin(Int16))
+        @test !(typemin(Int16) >= FD{Int8, 0}(-1) >= typemax(Int16))
+        @test !(typemin(Int16) >= FD{Int8, 2}(-1) >= typemax(Int16))
+    end
 end
 
 @testset "128-bit conversion correctness" begin

--- a/test/FixedDecimal.jl
+++ b/test/FixedDecimal.jl
@@ -317,11 +317,15 @@ end
     @test FD{Int16, 4}(1) < FD{Int8, 0}(4)  # FD{Int16,4}(4) doesn't fit
 
     # less precision allows smaller numbers
-    @test typemin(FD{Int8, 1}) < typemin(FD{Int8,2})
+    @test typemin(FD{Int8, 1}) <  typemin(FD{Int8,2})
     @test typemin(FD{Int8, 1}) <= typemin(FD{Int8,2})
+    @test typemin(FD{Int8, 2}) >  typemin(FD{Int8,1})
+    @test typemin(FD{Int8, 2}) >= typemin(FD{Int8,1})
     # less precision allows bigger numbers
-    @test typemax(FD{Int8, 1}) > typemax(FD{Int8,2})
+    @test typemax(FD{Int8, 1}) >  typemax(FD{Int8,2})
     @test typemax(FD{Int8, 1}) >= typemax(FD{Int8,2})
+    @test typemax(FD{Int8, 2}) <  typemax(FD{Int8,1})
+    @test typemax(FD{Int8, 2}) <= typemax(FD{Int8,1})
 
     @testset "Integer and FD" begin
         @test 1 <= FD{Int8, 2}(1) <= 1


### PR DESCRIPTION
In these cases, we were previously returning the wrong result. 😓 
```julia
julia> @test typemin(Int8) < FD{Int8, 2}(-1) < typemax(Int8)
Test Failed at REPL[27]:1
  Expression: typemin(Int8) < FD{Int8, 2}(-1) < typemax(Int8)
   Evaluated: -128 < FixedDecimal{Int8,2}(-1.00) < 127

julia> @test typemin(FD{Int8, 1}) < typemin(FD{Int8,2})
Test Failed at REPL[34]:1
  Expression: typemin(FD{Int8, 1}) < typemin(FD{Int8, 2})
   Evaluated: FixedDecimal{Int8,1}(-12.8) < FixedDecimal{Int8,2}(-1.28)
```
Now those tests pass.