### PR TITLE
Use Int256 to reduce BigInts in FD operations.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FixedPointDecimals"
 uuid = "fb4d412d-6eee-574d-9565-ede6634db7b0"
 authors = ["Fengyang Wang <fengyang.wang.0@gmail.com>", "Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 
 [compat]
 Parsers = "2.7"
+BitIntegers = "0.3.1"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Fengyang Wang <fengyang.wang.0@gmail.com>", "Curtis Vogt <curtis.vog
 version = "0.5.2"
 
 [deps]
+BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 
 [compat]

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -123,17 +123,16 @@ end
 # Custom widemul implementation to avoid the cost of widening to BigInt.
 # FD{Int128} operations should widen to 256 bits internally, rather than to a BigInt.
 const BitInteger128 = Union{Int128, UInt128}
-_widemul(x, y) = widemul(x, y)
-_widemul(x::BitInteger128, y) = _widemul(promote(x, y)...)
-_widemul(x, y::BitInteger128) = _widemul(promote(x, y)...)
-_widemul(x::Int128, y::Int128) = BitIntegers.Int256(x) * BitIntegers.Int256(y)
-_widemul(x::UInt128, y::UInt128) = BitIntegers.UInt256(x) * BitIntegers.UInt256(y)
+_widemul(x, y) = _widen(x) * _widen(y)
+_widemul(x::Signed,y::Unsigned) = _widen(x) * signed(_widen(y))
+_widemul(x::Unsigned,y::Signed) = signed(_widen(x)) * _widen(y)
 
 # Custom widen implementation to avoid the cost of widening to BigInt.
 # FD{Int128} operations should widen to 256 bits internally, rather than to a BigInt.
 _widen(::Type{Int128}) = BitIntegers.Int256
 _widen(::Type{UInt128}) = BitIntegers.UInt256
-_widen(t) = widen(t)
+_widen(t::Type) = widen(t)
+_widen(x::T) where {T} = (_widen(T))(x)
 
 
 (::Type{T})(x::Real) where {T <: FD} = convert(T, x)

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -175,7 +175,9 @@ function _round_to_nearest(quotient::T,
                            divisor::T,
                            ::RoundingMode{M}=RoundNearest) where {T <: Integer, M}
     halfdivisor = divisor >> 1
-    if iseven(divisor) && remainder == halfdivisor
+    # PERF Note: Only need the last bit to check iseven, and default iseven(Int256)
+    # allocates, so we truncate first.
+    if iseven((divisor % Int8)) && remainder == halfdivisor
         # `:NearestTiesAway` will tie away from zero, e.g. -8.5 ->
         # -9. `:NearestTiesUp` will always ties towards positive
         # infinity. `:Nearest` will tie towards the nearest even


### PR DESCRIPTION
We do not here explicitly introduce support for FD{BitIntegers.Int256}, though that should work out of the box both before and after this PR.

Rather, this PR _uses_ a (U)Int256 under the hood to prevent allocations from Int128 widening to BigInt in FD operations.
Unfortunately, `rem` and `mod` on BitIntegers.Int256 still fall-back to a BigInt ([see the note here](https://github.com/rfourquet/BitIntegers.jl/blob/deb17db47649cc59b49a3dfd29d74efa311590d7/src/BitIntegers.jl#L410-L414)), so this doesn't completely eliminate the BigInt allocs. But it does reduce them.

------

This is a pretty small PR, but it should have a big impact on users of `FD{Int128}`.

Before:
```julia
julia> @btime fd * fd setup = (fd = FixedDecimal{Int128,3}(1.234))
  392.413 ns (24 allocations: 464 bytes)
FixedDecimal{Int128,3}(1.523)
```
After:
```julia
julia> @btime fd * fd setup = (fd = FixedDecimal{Int128,3}(1.234))
  213.039 ns (12 allocations: 240 bytes)
FixedDecimal{Int128,3}(1.523)
```