### PR TITLE
Fix world age warnings from accessing binding before definiton 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FixedPointDecimals"
 uuid = "fb4d412d-6eee-574d-9565-ede6634db7b0"
 authors = ["Fengyang Wang <fengyang.wang.0@gmail.com>", "Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -47,11 +47,12 @@ const FMAFloat = Union{Float16, Float32, Float64, BigFloat}
 
 for fn in [:trunc, :floor, :ceil]
     fnname = Symbol(fn, "mul")
+    fnname_str = String(fnname)
     opp_fn = fn == :floor ? :ceil : :floor
 
     @eval begin
         @doc """
-            $($fnname)(I, x, y) :: I
+            $($fnname_str)(I, x, y) :: I
 
         Compute `$($fn)(I, x * y)`, returning the result as type `I`. For
         floating point values, this function can be more accurate than


### PR DESCRIPTION
Close #107

This warning is only present starting in Julia 1.12

Presumably the issue is with the docstring resolving the binding `fnname` before it's actually been defined. I don't fully understand the problem but this fixes it 🤷‍♂️ 
