### PR TITLE
Better handle different backing types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FixedPointDecimals"
 uuid = "fb4d412d-6eee-574d-9565-ede6634db7b0"
 authors = ["Fengyang Wang <fengyang.wang.0@gmail.com>", "Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "0.6"
+version = "0.6.0"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FixedPointDecimals"
 uuid = "fb4d412d-6eee-574d-9565-ede6634db7b0"
 authors = ["Fengyang Wang <fengyang.wang.0@gmail.com>", "Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "0.5.5"
+version = "0.6"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -419,17 +419,11 @@ function Base.add_with_overflow(x::T, y::T) where {T<:FD}
     z, b = Base.add_with_overflow(x.i, y.i)
     return (reinterpret(T, z), b)
 end
-Base.Checked.add_with_overflow(x::FD, y::FD) = Base.Checked.add_with_overflow(promote(x, y)...)
-Base.Checked.add_with_overflow(x::FD, y) = Base.Checked.add_with_overflow(promote(x, y)...)
-Base.Checked.add_with_overflow(x, y::FD) = Base.Checked.add_with_overflow(promote(x, y)...)
 
 function Base.sub_with_overflow(x::T, y::T) where {T<:FD}
     z, b = Base.sub_with_overflow(x.i, y.i)
     return (reinterpret(T, z), b)
 end
-Base.Checked.sub_with_overflow(x::FD, y::FD) = Base.Checked.sub_with_overflow(promote(x, y)...)
-Base.Checked.sub_with_overflow(x::FD, y) = Base.Checked.sub_with_overflow(promote(x, y)...)
-Base.Checked.sub_with_overflow(x, y::FD) = Base.Checked.sub_with_overflow(promote(x, y)...)
 
 function Base.Checked.mul_with_overflow(x::FD{T,f}, y::FD{T,f}) where {T<:Integer,f}
     powt = coefficient(FD{T, f})
@@ -437,9 +431,6 @@ function Base.Checked.mul_with_overflow(x::FD{T,f}, y::FD{T,f}) where {T<:Intege
     v = _round_to_nearest(quotient, remainder, powt)
     return (reinterpret(FD{T,f}, Base.trunc_int(T, v)), v < typemin(T) || v > typemax(T))
 end
-Base.Checked.mul_with_overflow(x::FD, y::FD) = Base.Checked.mul_with_overflow(promote(x, y)...)
-Base.Checked.mul_with_overflow(x::FD, y) = Base.Checked.mul_with_overflow(promote(x, y)...)
-Base.Checked.mul_with_overflow(x, y::FD) = Base.Checked.mul_with_overflow(promote(x, y)...)
 
 Base.checked_add(x::FD, y::FD) = Base.checked_add(promote(x, y)...)
 Base.checked_sub(x::FD, y::FD) = Base.checked_sub(promote(x, y)...)

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -471,7 +471,7 @@ function fld_with_overflow(x::FD{T,f}, y::FD{T,f}) where {T<:Integer,f}
     C = coefficient(FD{T, f})
     # This case will break the fld call below. This can only happen when f is 0 as y.i
     # cannot be -1 otherwise.
-    if x.i == typemin(T) && y.i == -1
+    if T <: Signed && x.i == typemin(T) && y.i == -1
         # To fld and overflow means reaching the max and adding 1, so typemin (x).
         return (x, true)
     end

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -430,7 +430,7 @@ function Base.Checked.mul_with_overflow(x::FD{T,f}, y::FD{T,f}) where {T<:Intege
     powt = coefficient(FD{T, f})
     quotient, remainder = fldmodinline(_widemul(x.i, y.i), powt)
     v = _round_to_nearest(quotient, remainder, powt)
-    return (reinterpret(FD{T,f}, Base.trunc_int(T, v)), v < typemin(T) || v > typemax(T))
+    return (reinterpret(FD{T,f}, rem(v, T)), v < typemin(T) || v > typemax(T))
 end
 
 # This does not exist in Base so is just part of this package.
@@ -445,7 +445,7 @@ overflow/underflow did in fact happen. Throws a DivideError on divide-by-zero.
 function div_with_overflow(x::FD{T,f}, y::FD{T,f}) where {T<:Integer,f}
     C = coefficient(FD{T, f})
     # This case will break the div call below.
-    if x.i == typemin(T) && y.i == -1
+    if T <: Signed && x.i == typemin(T) && y.i == -1
         # To perform the div and overflow means reaching the max and adding 1, so typemin.
         return (x, true)
     end

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -417,11 +417,7 @@ function Base.Checked.mul_with_overflow(x::FD{T,f}, y::FD{T,f}) where {T<:Intege
     powt = coefficient(FD{T, f})
     quotient, remainder = fldmodinline(_widemul(x.i, y.i), powt)
     v = _round_to_nearest(quotient, remainder, powt)
-    return if typemin(T) <= v <= typemax(T)
-        return (reinterpret(FD{T,f}, T(v)), false)
-    else
-        return (reinterpret(FD{T,f}, Base.trunc_int(T, v)), true)
-    end
+    return (reinterpret(FD{T,f}, Base.trunc_int(T, v)), v < typemin(T) || v > typemax(T))
 end
 Base.Checked.mul_with_overflow(x::FD, y::FD) = Base.Checked.mul_with_overflow(promote(x, y)...)
 Base.Checked.mul_with_overflow(x::FD, y) = Base.Checked.mul_with_overflow(promote(x, y)...)

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -453,6 +453,78 @@ function div_with_overflow(x::FD{T,f}, y::FD{T,f}) where {T<:Integer,f}
     return (reinterpret(FD{T,f}, v), b)
 end
 
+# Does not exist in Base.Checked, so just exists in this package.
+@doc """
+    FixedPointDecimals.fld_with_overflow(x::FD, y::FD)::Tuple{FD,Bool}
+
+Calculates the largest integer less than or equal to `x / y`, checking for overflow errors
+where applicable, returning the result and a boolean indicating whether overflow occured.
+Throws a DivideError on divide-by-zero.
+
+The overflow protection may impose a perceptible performance penalty.
+
+See also:
+- `Base.checked_fld`.
+"""
+function fld_with_overflow(x::FD{T,f}, y::FD{T,f}) where {T<:Integer,f}
+    C = coefficient(FD{T, f})
+    # This case will break the fld call below. This can only happen when f is 0 as y.i
+    # cannot be -1 otherwise.
+    if x.i == typemin(T) && y.i == -1
+        # To fld and overflow means reaching the max and adding 1, so typemin (x).
+        return (x, true)
+    end
+    # Note: The fld() will already throw for divide-by-zero, that's not an overflow.
+    v, b = Base.Checked.mul_with_overflow(C, fld(x.i, y.i))
+    return (reinterpret(FD{T, f}, v), b)
+end
+
+"""
+    FixedPointDecimals.rdiv_with_overflow(x::FD, y::FD)::Tuple{FD,Bool}
+
+Calculates `x / y`, checking for overflow errors where applicable, returning the result
+and a boolean indicating whether overflow occured. Throws a DivideError on divide-by-zero.
+
+The overflow protection may impose a perceptible performance penalty.
+
+See also:
+- `Base.checked_rdiv`.
+"""
+function rdiv_with_overflow(x::FD{T,f}, y::FD{T,f}) where {T<:Integer,f}
+    powt = coefficient(FD{T, f})
+    # No multiplication can reach the typemax/typemin of a wider type, thus no typemin / -1.
+    quotient, remainder = fldmod(_widemul(x.i, powt), y.i)
+    # quotient is necessarily not typemax/typemin. x.i * powt cannot reach typemax/typemin
+    # of the widened type and y.i is an integer. Thus the following call cannot overflow.
+    v = _round_to_nearest(quotient, remainder, y.i)
+    return (reinterpret(FD{T,f}, rem(v, T)), v < typemin(T) || v > typemax(T))
+end
+
+# These functions allow us to perform division with integers outside of the range of the
+# FixedDecimal.
+function rdiv_with_overflow(x::Integer, y::FD{T, f}) where {T<:Integer, f}
+    powt = coefficient(FD{T, f})
+    powtsq = _widemul(powt, powt)
+    # No multiplication can reach the typemax/typemin of a wider type, thus no typemin / -1.
+    quotient, remainder = fldmod(_widemul(x, powtsq), y.i)
+    # Same deal as previous overload as to why this will not overload. Note that all
+    # multiplication operations were widemuls.
+    v = _round_to_nearest(quotient, remainder, y.i)
+    return (reinterpret(FD{T,f}, rem(v, T)), v < typemin(T) || v > typemax(T))
+end
+function rdiv_with_overflow(x::FD{T, f}, y::Integer) where {T<:Integer, f}
+    if T <: Signed && x.i == typemin(T) && y == -1
+        # typemin / -1 for signed integers wraps, giving typemin (x) again.
+        return (x, true)
+    end
+
+    quotient, remainder = fldmod(x.i, y)
+    # It is impossible for both the quotient to be typemax/typemin AND remainder to be
+    # non-zero because y is an integer. Thus the following call cannot overflow.
+    v = _round_to_nearest(quotient, remainder, y)
+    return (reinterpret(FD{T, f}, v), false)
+end
+
 Base.checked_add(x::FD, y::FD) = Base.checked_add(promote(x, y)...)
 Base.checked_sub(x::FD, y::FD) = Base.checked_sub(promote(x, y)...)
 Base.checked_mul(x::FD, y::FD) = Base.checked_mul(promote(x, y)...)
@@ -546,28 +618,22 @@ See also:
 checked_rdiv(x::FD, y::FD) = checked_rdiv(promote(x, y)...)
 
 function checked_rdiv(x::FD{T,f}, y::FD{T,f}) where {T<:Integer,f}
-    powt = coefficient(FD{T, f})
-    quotient, remainder = fldmod(_widemul(x.i, powt), y.i)
-    v = _round_to_nearest(quotient, remainder, y.i)
-    typemin(T) <= v <= typemax(T) || Base.Checked.throw_overflowerr_binaryop(:/, x, y)
-    return reinterpret(FD{T, f}, v)
+    (z, b) = rdiv_with_overflow(x, y)
+    b && Base.Checked.throw_overflowerr_binaryop(:/, x, y)
+    return z
 end
 
 # These functions allow us to perform division with integers outside of the range of the
 # FixedDecimal.
 function checked_rdiv(x::Integer, y::FD{T, f}) where {T<:Integer, f}
-    powt = coefficient(FD{T, f})
-    powtsq = _widemul(powt, powt)
-    quotient, remainder = fldmod(_widemul(x, powtsq), y.i)
-    v = _round_to_nearest(quotient, remainder, y.i)
-    typemin(T) <= v <= typemax(T) || Base.Checked.throw_overflowerr_binaryop(:/, x, y)
-    reinterpret(FD{T, f}, v)
+    (z, b) = rdiv_with_overflow(x, y)
+    b && Base.Checked.throw_overflowerr_binaryop(:/, x, y)
+    return z
 end
 function checked_rdiv(x::FD{T, f}, y::Integer) where {T<:Integer, f}
-    quotient, remainder = fldmod(x.i, y)
-    v = _round_to_nearest(quotient, remainder, y)
-    typemin(T) <= v <= typemax(T) || Base.Checked.throw_overflowerr_binaryop(:/, x, y)
-    reinterpret(FD{T, f}, v)
+    (z, b) = rdiv_with_overflow(x, y)
+    b && Base.Checked.throw_overflowerr_binaryop(:/, x, y)
+    return z
 end
 
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -397,6 +397,36 @@ end
 
 # --- Checked arithmetic ---
 
+function Base.add_with_overflow(x::T, y::T) where {T<:FD}
+    z, b = Base.add_with_overflow(x.i, y.i)
+    return (reinterpret(T, z), b)
+end
+Base.Checked.add_with_overflow(x::FD, y::FD) = Base.Checked.add_with_overflow(promote(x, y)...)
+Base.Checked.add_with_overflow(x::FD, y) = Base.Checked.add_with_overflow(promote(x, y)...)
+Base.Checked.add_with_overflow(x, y::FD) = Base.Checked.add_with_overflow(promote(x, y)...)
+
+function Base.sub_with_overflow(x::T, y::T) where {T<:FD}
+    z, b = Base.sub_with_overflow(x.i, y.i)
+    return (reinterpret(T, z), b)
+end
+Base.Checked.sub_with_overflow(x::FD, y::FD) = Base.Checked.sub_with_overflow(promote(x, y)...)
+Base.Checked.sub_with_overflow(x::FD, y) = Base.Checked.sub_with_overflow(promote(x, y)...)
+Base.Checked.sub_with_overflow(x, y::FD) = Base.Checked.sub_with_overflow(promote(x, y)...)
+
+function Base.Checked.mul_with_overflow(x::FD{T,f}, y::FD{T,f}) where {T<:Integer,f}
+    powt = coefficient(FD{T, f})
+    quotient, remainder = fldmodinline(_widemul(x.i, y.i), powt)
+    v = _round_to_nearest(quotient, remainder, powt)
+    return if typemin(T) <= v <= typemax(T)
+        return (reinterpret(FD{T,f}, T(v)), false)
+    else
+        return (reinterpret(FD{T,f}, Base.trunc_int(T, v)), true)
+    end
+end
+Base.Checked.mul_with_overflow(x::FD, y::FD) = Base.Checked.mul_with_overflow(promote(x, y)...)
+Base.Checked.mul_with_overflow(x::FD, y) = Base.Checked.mul_with_overflow(promote(x, y)...)
+Base.Checked.mul_with_overflow(x, y::FD) = Base.Checked.mul_with_overflow(promote(x, y)...)
+
 Base.checked_add(x::FD, y::FD) = Base.checked_add(promote(x, y)...)
 Base.checked_sub(x::FD, y::FD) = Base.checked_sub(promote(x, y)...)
 Base.checked_mul(x::FD, y::FD) = Base.checked_mul(promote(x, y)...)
@@ -424,21 +454,19 @@ Base.checked_mod(x::FD, y) = Base.checked_mod(promote(x, y)...)
 Base.checked_mod(x, y::FD) = Base.checked_mod(promote(x, y)...)
 
 function Base.checked_add(x::T, y::T) where {T<:FD}
-    z, b = Base.add_with_overflow(x.i, y.i)
+    z, b = Base.Checked.add_with_overflow(x, y)
     b && Base.Checked.throw_overflowerr_binaryop(:+, x, y)
-    return reinterpret(T, z)
+    return z
 end
 function Base.checked_sub(x::T, y::T) where {T<:FD}
-    z, b = Base.sub_with_overflow(x.i, y.i)
+    z, b = Base.Checked.sub_with_overflow(x, y)
     b && Base.Checked.throw_overflowerr_binaryop(:-, x, y)
-    return reinterpret(T, z)
+    return z
 end
 function Base.checked_mul(x::FD{T,f}, y::FD{T,f}) where {T<:Integer,f}
-    powt = coefficient(FD{T, f})
-    quotient, remainder = fldmodinline(_widemul(x.i, y.i), powt)
-    v = _round_to_nearest(quotient, remainder, powt)
-    typemin(T) <= v <= typemax(T) || Base.Checked.throw_overflowerr_binaryop(:*, x, y)
-    return reinterpret(FD{T, f}, T(v))
+    z, b = Base.Checked.mul_with_overflow(x, y)
+    b && Base.Checked.throw_overflowerr_binaryop(:*, x, y)
+    return z
 end
 # Checked division functions
 for divfn in [:div, :fld, :cld]

--- a/test/FixedDecimal.jl
+++ b/test/FixedDecimal.jl
@@ -777,6 +777,8 @@ end
     end
 
     @testset "limits: with_overflow math" begin
+        using FixedPointDecimals: rdiv_with_overflow, fld_with_overflow
+
         # Easy to reason about cases of overflow:
         @test Base.Checked.add_with_overflow(FD{Int8,2}(1), FD{Int8,2}(1)) == (FD{Int8,2}(-0.56), true)
         @test Base.Checked.add_with_overflow(FD{Int8,2}(1), FD{Int8,2}(1)) == (FD{Int8,2}(-0.56), true)
@@ -788,6 +790,16 @@ end
         @test div_with_overflow(FD{Int8,2}(1), FD{Int8,2}(0.5)) == (FD{Int8,2}(-0.56), true)
         @test div_with_overflow(typemin(FD{Int32,0}), FD{Int32,0}(-1)) == (typemin(FD{Int32,0}), true)
         @test div_with_overflow(FD{Int16,1}(1639), FD{Int16,1}(0.5)) == (FD{Int16,1}(-3275.6), true)
+
+        @test rdiv_with_overflow(Int8(1), FD{Int8,2}(0.7)) == (FD{Int8,2}(-1.13), true)
+        @test rdiv_with_overflow(FD{Int16,2}(165), FD{Int16,2}(0.5)) == (FD{Int16,2}(-325.36), true)
+        @test rdiv_with_overflow(FD{Int16,2}(-165), FD{Int16,2}(0.5)) == (FD{Int16,2}(325.36), true)
+        @test rdiv_with_overflow(typemin(FD{Int64,8}), Int32(-1)) == (typemin(FD{Int64,8}), true)
+        @test rdiv_with_overflow(typemin(FD{Int64,0}), FD{Int64,0}(-1)) == (typemin(FD{Int64,0}), true)
+
+        @test fld_with_overflow(FD{Int8,2}(-1), FD{Int8,2}(0.9)) == (FD{Int8,2}(0.56), true)
+        @test fld_with_overflow(typemin(FD{Int64,0}), FD{Int64,0}(-1)) == (typemin(FD{Int64,0}), true)
+        @test fld_with_overflow(FD{Int8,1}(7), FD{Int8,1}(0.5)) == (FD{Int8,1}(-11.6), true)
 
         @testset "with_overflow math corner cases" begin
             @testset for I in (Int128, UInt128, Int8, UInt8), f in (0,2)
@@ -823,7 +835,14 @@ end
                     issigned(I) && @test_throws DivideError div_with_overflow(typemax(T), T(0))
                     issigned(I) && @test_throws DivideError div_with_overflow(typemin(T), T(0))
                     issigned(I) && @test div_with_overflow(typemin(T), -eps(T))[2]
+
+                    @test fld_with_overflow(typemax(T), eps(T))[2]
+                    issigned(I) && @test fld_with_overflow(typemin(T), eps(T))[2]
+                    issigned(I) && @test fld_with_overflow(typemax(T), -eps(T))[2]
                 end
+
+                @test_throws DivideError rdiv_with_overflow(typemax(T), T(0))
+                @test_throws DivideError rdiv_with_overflow(typemin(T), T(0))
             end
         end
 
@@ -848,6 +867,16 @@ end
             @test div_with_overflow(FD{Int128,14}(10), FD{Int128,14}(20.1)) == (FD{Int128,14}(0), false)
             @test div_with_overflow(FD{Int128,30}(10.1), FD{Int128,30}(1)) == (FD{Int128,30}(10), false)
             @test div_with_overflow(typemin(FD{Int32,8}(1)), FD{Int32,8}(-1)) == (21, false)
+
+            @test rdiv_with_overflow(Int8(1), FD{Int8,2}(0.8)) == (FD{Int8,2}(1.25), false)
+            @test rdiv_with_overflow(FD{Int64,8}(5), FD{Int64,8}(2)) == (FD{Int64,8}(2.5), false)
+            @test rdiv_with_overflow(FD{Int64,8}(5), FD{Int64,8}(0.5)) == (FD{Int64,8}(10), false)
+            @test rdiv_with_overflow(FD{Int128,0}(20000), Int32(5000)) == (FD{Int128,0}(4), false)
+
+            @test fld_with_overflow(typemax(FD{Int128,38}), FD{Int128,38}(1)) == (FD{Int128,38}(1), false)
+            @test fld_with_overflow(FD{Int64,8}(20.5), FD{Int64,8}(2.1)) == (FD{Int64,8}(9), false)
+            @test fld_with_overflow(FD{Int8,0}(-5), FD{Int8,0}(-1)) == (FD{Int8,0}(5), false)
+            @test fld_with_overflow(FD{Int8,2}(0.99), FD{Int8,2}(0.5)) == (FD{Int8,2}(1), false)
         end
     end
 

--- a/test/FixedDecimal.jl
+++ b/test/FixedDecimal.jl
@@ -834,7 +834,7 @@ end
             end
         end
 
-        @testset "non-overflow with_overflow math" begin
+        @testset "non-overflowing with_overflow math" begin
             @test Base.Checked.add_with_overflow(1, FD{Int8,1}(1.1)) == (FD{Int8,1}(2.1), false)
             @test Base.Checked.add_with_overflow(FD{Int8,1}(1.1), 1) == (FD{Int8,1}(2.1), false)
             @test Base.Checked.add_with_overflow(FD{Int64,8}(30.123), FD{Int64,8}(30)) == (FD{Int64,8}(60.123), false)

--- a/test/FixedDecimal.jl
+++ b/test/FixedDecimal.jl
@@ -776,6 +776,82 @@ end
         @test FD{Int8,1}(2) / Int8(20) == FD{Int8,1}(0.1)
     end
 
+    @testset "limits: with_overflow math" begin
+        # Easy to reason about cases of overflow:
+        @test Base.Checked.add_with_overflow(FD{Int8,2}(1), FD{Int8,2}(1)) == (FD{Int8,2}(-0.56), true)
+        @test Base.Checked.add_with_overflow(FD{Int8,2}(1), 1) == (FD{Int8,2}(-0.56), true)
+        @test Base.Checked.add_with_overflow(FD{Int8,2}(1), FD{Int8,2}(0.4)) == (FD{Int8,2}(-1.16), true)
+
+        @test Base.Checked.sub_with_overflow(FD{Int8,2}(1), FD{Int8,2}(-1)) == (FD{Int8,2}(-0.56), true)
+        @test Base.Checked.sub_with_overflow(1, FD{Int8,2}(-1)) == (FD{Int8,2}(-0.56), true)
+        @test Base.Checked.sub_with_overflow(FD{Int8,2}(-1), FD{Int8,2}(0.4)) == (FD{Int8,2}(1.16), true)
+
+        @test Base.Checked.mul_with_overflow(FD{Int8,2}(1.2), FD{Int8,2}(1.2)) == (FD{Int8,2}(-1.12), true)
+        @test Base.Checked.mul_with_overflow(FD{Int8,1}(12), 2) == (FD{Int8,1}(-1.6), true)
+        @test Base.Checked.mul_with_overflow(FD{Int8,0}(120), 2) == (FD{Int8,0}(-16), true)
+        @test Base.Checked.mul_with_overflow(120, FD{Int8,0}(2)) == (FD{Int8,0}(-16), true)
+
+        @testset "with_overflow math corner cases" begin
+            @testset for I in (Int128, UInt128, Int8, UInt8), f in (0,2)
+            T = FD{I, f}
+                issigned(I) = signed(I) === I
+
+                @test Base.Checked.add_with_overflow(typemax(T), eps(T)) == (typemax(T) + eps(T), true)
+                issigned(I) && @test Base.Checked.add_with_overflow(typemin(T), -eps(T)) == (typemin(T) + -eps(T), true)
+                @test Base.Checked.add_with_overflow(typemax(T), 1) == (typemax(T) + 1, true)
+                @test Base.Checked.add_with_overflow(1, typemax(T)) == (typemax(T) + 1, true)
+
+                @test Base.Checked.sub_with_overflow(typemin(T), eps(T)) == (typemin(T) - eps(T), true)
+                issigned(I) && @test Base.Checked.sub_with_overflow(typemax(T), -eps(T)) == (typemax(T) - -eps(T), true)
+                @test Base.Checked.sub_with_overflow(typemin(T), 1) == (typemin(T) - 1, true)
+                if issigned(I) && 2.0 <= typemax(T)
+                    @test Base.Checked.sub_with_overflow(-2, typemax(T)) == (-2 -typemax(T), true)
+                end
+
+                @test Base.Checked.mul_with_overflow(typemax(T), typemax(T)) == (typemax(T) * typemax(T), true)
+                issigned(I) && @test Base.Checked.mul_with_overflow(typemin(T), typemax(T)) == (typemin(T) * typemax(T), true)
+                if 2.0 <= typemax(T)
+                    @test Base.Checked.mul_with_overflow(typemax(T), 2) == (typemax(T) * 2, true)
+                    @test Base.Checked.mul_with_overflow(2, typemax(T)) == (2 * typemax(T), true)
+                    issigned(I) && @test Base.Checked.mul_with_overflow(typemin(T), 2) == (typemin(T) * 2, true)
+                    issigned(I) && @test Base.Checked.mul_with_overflow(2, typemin(T)) == (2 * typemin(T), true)
+                end
+            end
+        end
+
+        @testset "with_overflow math promotions" begin
+            x = FD{Int8,1}(1)
+            y = FD{Int64,1}(2)
+            @testset for op in (
+                Base.Checked.add_with_overflow, Base.Checked.sub_with_overflow,
+                Base.Checked.mul_with_overflow,
+            )
+                @test op(x, y) === op(FD{Int64,1}(1), y)
+                @test op(y, x) === op(y, FD{Int64,1}(1))
+
+                @test op(x, 2) === op(x, FD{Int8,1}(2))
+                @test op(2, x) === op(FD{Int8,1}(2), x)
+            end
+        end
+
+        @testset "non-overflow with_overflow math" begin
+            @test Base.Checked.add_with_overflow(1, FD{Int8,1}(1.1)) == (FD{Int8,1}(2.1), false)
+            @test Base.Checked.add_with_overflow(FD{Int8,1}(1.1), 1) == (FD{Int8,1}(2.1), false)
+            @test Base.Checked.add_with_overflow(FD{Int64,8}(30.123), FD{Int64,8}(30)) == (FD{Int64,8}(60.123), false)
+            @test Base.Checked.add_with_overflow(FD{Int64,8}(30.123), FD{Int64,5}(30)) == (FD{Int64,8}(60.123), false)
+
+            @test Base.Checked.sub_with_overflow(3, FD{Int16,2}(2.5)) == (FD{Int16,1}(0.5), false)
+            @test Base.Checked.sub_with_overflow(FD{Int16,2}(2.5), 3) == (FD{Int16,1}(-0.5), false)
+            @test Base.Checked.sub_with_overflow(FD{Int32,4}(10.11), FD{Int32,4}(2)) == (FD{Int32,4}(8.11), false)
+            @test Base.Checked.sub_with_overflow(FD{Int32,4}(10.11), FD{Int32,3}(2)) == (FD{Int32,4}(8.11), false)
+
+            @test Base.Checked.mul_with_overflow(4, FD{Int64,6}(2.22)) == (FD{Int64,6}(8.88), false)
+            @test Base.Checked.mul_with_overflow(FD{Int64,6}(2.22), 4) == (FD{Int64,6}(8.88), false)
+            @test Base.Checked.mul_with_overflow(FD{Int128,14}(10), FD{Int128,14}(20.1)) == (FD{Int128,14}(201), false)
+            @test Base.Checked.mul_with_overflow(FD{Int128,30}(10.11), FD{Int128,0}(1)) == (FD{Int128,30}(10.11), false)
+        end
+    end
+
     @testset "limits: overflow checked math" begin
         # Easy to reason about cases of overflow:
         @test_throws OverflowError Base.checked_add(FD{Int8,2}(1), FD{Int8,2}(1))

--- a/test/FixedDecimal.jl
+++ b/test/FixedDecimal.jl
@@ -843,6 +843,13 @@ end
 
                 @test_throws DivideError rdiv_with_overflow(typemax(T), T(0))
                 @test_throws DivideError rdiv_with_overflow(typemin(T), T(0))
+                @test_throws DivideError rdiv_with_overflow(eps(T), T(0))
+                @test_throws DivideError rdiv_with_overflow(-eps(T), T(0))
+
+                @test_throws DivideError fld_with_overflow(typemax(T), T(0))
+                @test_throws DivideError fld_with_overflow(typemin(T), T(0))
+                @test_throws DivideError fld_with_overflow(eps(T), T(0))
+                @test_throws DivideError fld_with_overflow(-eps(T), T(0))
             end
         end
 

--- a/test/FixedDecimal.jl
+++ b/test/FixedDecimal.jl
@@ -779,17 +779,11 @@ end
     @testset "limits: with_overflow math" begin
         # Easy to reason about cases of overflow:
         @test Base.Checked.add_with_overflow(FD{Int8,2}(1), FD{Int8,2}(1)) == (FD{Int8,2}(-0.56), true)
-        @test Base.Checked.add_with_overflow(FD{Int8,2}(1), 1) == (FD{Int8,2}(-0.56), true)
+        @test Base.Checked.add_with_overflow(FD{Int8,2}(1), FD{Int8,2}(1)) == (FD{Int8,2}(-0.56), true)
         @test Base.Checked.add_with_overflow(FD{Int8,2}(1), FD{Int8,2}(0.4)) == (FD{Int8,2}(-1.16), true)
-
         @test Base.Checked.sub_with_overflow(FD{Int8,2}(1), FD{Int8,2}(-1)) == (FD{Int8,2}(-0.56), true)
-        @test Base.Checked.sub_with_overflow(1, FD{Int8,2}(-1)) == (FD{Int8,2}(-0.56), true)
         @test Base.Checked.sub_with_overflow(FD{Int8,2}(-1), FD{Int8,2}(0.4)) == (FD{Int8,2}(1.16), true)
-
         @test Base.Checked.mul_with_overflow(FD{Int8,2}(1.2), FD{Int8,2}(1.2)) == (FD{Int8,2}(-1.12), true)
-        @test Base.Checked.mul_with_overflow(FD{Int8,1}(12), 2) == (FD{Int8,1}(-1.6), true)
-        @test Base.Checked.mul_with_overflow(FD{Int8,0}(120), 2) == (FD{Int8,0}(-16), true)
-        @test Base.Checked.mul_with_overflow(120, FD{Int8,0}(2)) == (FD{Int8,0}(-16), true)
 
         @testset "with_overflow math corner cases" begin
             @testset for I in (Int128, UInt128, Int8, UInt8), f in (0,2)
@@ -798,57 +792,42 @@ end
 
                 @test Base.Checked.add_with_overflow(typemax(T), eps(T)) == (typemax(T) + eps(T), true)
                 issigned(I) && @test Base.Checked.add_with_overflow(typemin(T), -eps(T)) == (typemin(T) + -eps(T), true)
-                @test Base.Checked.add_with_overflow(typemax(T), 1) == (typemax(T) + 1, true)
-                @test Base.Checked.add_with_overflow(1, typemax(T)) == (typemax(T) + 1, true)
+                @test Base.Checked.add_with_overflow(typemax(T), T(1)) == (typemax(T) + 1, true)
+                @test Base.Checked.add_with_overflow(T(1), typemax(T)) == (typemax(T) + 1, true)
 
                 @test Base.Checked.sub_with_overflow(typemin(T), eps(T)) == (typemin(T) - eps(T), true)
                 issigned(I) && @test Base.Checked.sub_with_overflow(typemax(T), -eps(T)) == (typemax(T) - -eps(T), true)
-                @test Base.Checked.sub_with_overflow(typemin(T), 1) == (typemin(T) - 1, true)
+                @test Base.Checked.sub_with_overflow(typemin(T), T(1)) == (typemin(T) - 1, true)
                 if issigned(I) && 2.0 <= typemax(T)
-                    @test Base.Checked.sub_with_overflow(-2, typemax(T)) == (-2 -typemax(T), true)
+                    @test Base.Checked.sub_with_overflow(T(-2), typemax(T)) == (-2 -typemax(T), true)
                 end
 
                 @test Base.Checked.mul_with_overflow(typemax(T), typemax(T)) == (typemax(T) * typemax(T), true)
                 issigned(I) && @test Base.Checked.mul_with_overflow(typemin(T), typemax(T)) == (typemin(T) * typemax(T), true)
                 if 2.0 <= typemax(T)
-                    @test Base.Checked.mul_with_overflow(typemax(T), 2) == (typemax(T) * 2, true)
-                    @test Base.Checked.mul_with_overflow(2, typemax(T)) == (2 * typemax(T), true)
-                    issigned(I) && @test Base.Checked.mul_with_overflow(typemin(T), 2) == (typemin(T) * 2, true)
-                    issigned(I) && @test Base.Checked.mul_with_overflow(2, typemin(T)) == (2 * typemin(T), true)
+                    @test Base.Checked.mul_with_overflow(typemax(T), T(2)) == (typemax(T) * 2, true)
+                    @test Base.Checked.mul_with_overflow(T(2), typemax(T)) == (2 * typemax(T), true)
+                    issigned(I) && @test Base.Checked.mul_with_overflow(typemin(T), T(2)) == (typemin(T) * 2, true)
+                    issigned(I) && @test Base.Checked.mul_with_overflow(T(2), typemin(T)) == (2 * typemin(T), true)
                 end
             end
         end
 
-        @testset "with_overflow math promotions" begin
-            x = FD{Int8,1}(1)
-            y = FD{Int64,1}(2)
-            @testset for op in (
-                Base.Checked.add_with_overflow, Base.Checked.sub_with_overflow,
-                Base.Checked.mul_with_overflow,
-            )
-                @test op(x, y) === op(FD{Int64,1}(1), y)
-                @test op(y, x) === op(y, FD{Int64,1}(1))
-
-                @test op(x, 2) === op(x, FD{Int8,1}(2))
-                @test op(2, x) === op(FD{Int8,1}(2), x)
-            end
-        end
-
         @testset "non-overflowing with_overflow math" begin
-            @test Base.Checked.add_with_overflow(1, FD{Int8,1}(1.1)) == (FD{Int8,1}(2.1), false)
-            @test Base.Checked.add_with_overflow(FD{Int8,1}(1.1), 1) == (FD{Int8,1}(2.1), false)
+            @test Base.Checked.add_with_overflow(FD{Int8,1}(1), FD{Int8,1}(1.1)) == (FD{Int8,1}(2.1), false)
+            @test Base.Checked.add_with_overflow(FD{Int8,1}(1.1), FD{Int8,1}(1)) == (FD{Int8,1}(2.1), false)
             @test Base.Checked.add_with_overflow(FD{Int64,8}(30.123), FD{Int64,8}(30)) == (FD{Int64,8}(60.123), false)
-            @test Base.Checked.add_with_overflow(FD{Int64,8}(30.123), FD{Int64,5}(30)) == (FD{Int64,8}(60.123), false)
+            @test Base.Checked.add_with_overflow(FD{Int64,8}(30.123), FD{Int64,8}(-50)) == (FD{Int64,8}(-19.877), false)
 
-            @test Base.Checked.sub_with_overflow(3, FD{Int16,2}(2.5)) == (FD{Int16,1}(0.5), false)
-            @test Base.Checked.sub_with_overflow(FD{Int16,2}(2.5), 3) == (FD{Int16,1}(-0.5), false)
+            @test Base.Checked.sub_with_overflow(FD{Int16,2}(3), FD{Int16,2}(2.5)) == (FD{Int16,1}(0.5), false)
+            @test Base.Checked.sub_with_overflow(FD{Int16,2}(2.5), FD{Int16,2}(3)) == (FD{Int16,1}(-0.5), false)
             @test Base.Checked.sub_with_overflow(FD{Int32,4}(10.11), FD{Int32,4}(2)) == (FD{Int32,4}(8.11), false)
-            @test Base.Checked.sub_with_overflow(FD{Int32,4}(10.11), FD{Int32,3}(2)) == (FD{Int32,4}(8.11), false)
+            @test Base.Checked.sub_with_overflow(FD{Int32,4}(10.11), FD{Int32,4}(-2)) == (FD{Int32,4}(12.11), false)
 
-            @test Base.Checked.mul_with_overflow(4, FD{Int64,6}(2.22)) == (FD{Int64,6}(8.88), false)
-            @test Base.Checked.mul_with_overflow(FD{Int64,6}(2.22), 4) == (FD{Int64,6}(8.88), false)
+            @test Base.Checked.mul_with_overflow(FD{Int64,6}(4), FD{Int64,6}(2.22)) == (FD{Int64,6}(8.88), false)
+            @test Base.Checked.mul_with_overflow(FD{Int64,6}(2.22), FD{Int64,6}(4)) == (FD{Int64,6}(8.88), false)
             @test Base.Checked.mul_with_overflow(FD{Int128,14}(10), FD{Int128,14}(20.1)) == (FD{Int128,14}(201), false)
-            @test Base.Checked.mul_with_overflow(FD{Int128,30}(10.11), FD{Int128,0}(1)) == (FD{Int128,30}(10.11), false)
+            @test Base.Checked.mul_with_overflow(FD{Int128,30}(10.1), FD{Int128,30}(1)) == (FD{Int128,30}(10.1), false)
         end
     end
 


### PR DESCRIPTION
`trunc_int` is for primitive types only. `typemin` on unsigned types is 0, which you can obviously divide by -1.