### PR TITLE
Better handle different backing types

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -430,7 +430,7 @@ function Base.Checked.mul_with_overflow(x::FD{T,f}, y::FD{T,f}) where {T<:Intege
     powt = coefficient(FD{T, f})
     quotient, remainder = fldmodinline(_widemul(x.i, y.i), powt)
     v = _round_to_nearest(quotient, remainder, powt)
-    return (reinterpret(FD{T,f}, Base.trunc_int(T, v)), v < typemin(T) || v > typemax(T))
+    return (reinterpret(FD{T,f}, rem(v, T)), v < typemin(T) || v > typemax(T))
 end
 
 # This does not exist in Base so is just part of this package.
@@ -445,7 +445,7 @@ overflow/underflow did in fact happen. Throws a DivideError on divide-by-zero.
 function div_with_overflow(x::FD{T,f}, y::FD{T,f}) where {T<:Integer,f}
     C = coefficient(FD{T, f})
     # This case will break the div call below.
-    if x.i == typemin(T) && y.i == -1
+    if T <: Signed && x.i == typemin(T) && y.i == -1
         # To perform the div and overflow means reaching the max and adding 1, so typemin.
         return (x, true)
     end


### PR DESCRIPTION
`trunc_int` is for primitive types only. `typemin` on unsigned types is 0 which you can obviously divide by -1.
