### PR TITLE
Explicitly qualify Base.Bool constructor

### DIFF
--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -727,7 +727,7 @@ end
 
 (::Type{T})(x::FD) where {T<:Union{AbstractFloat,Integer,Rational}} = convert(T, x)
 # Need to avoid ambiguity:
-Bool(x::FD) = convert(Bool, x)
+Base.Bool(x::FD) = convert(Bool, x)
 
 Base.promote_rule(::Type{FD{T, f}}, ::Type{<:Integer}) where {T, f} = FD{T, f}
 Base.promote_rule(::Type{<:FD}, ::Type{TF}) where {TF <: AbstractFloat} = TF


### PR DESCRIPTION
Fixes a precompilation warning in julia 1.12:
```
┌ FixedPointDecimals
│  WARNING: Constructor for type "Bool" was extended in `FixedPointDecimals` without explicit qualification or import.
│    NOTE: Assumed "Bool" refers to `Base.Bool`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function Bool end`.
│    Hint: To silence the warning, qualify `Bool` as `Base.Bool` in the method signature or explicitly `import Base: Bool`.
└  
```