### PR TITLE
Use `OncePerTask` instead of a handmade thread local cache

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FixedPointDecimals"
 uuid = "fb4d412d-6eee-574d-9565-ede6634db7b0"
 authors = ["Fengyang Wang <fengyang.wang.0@gmail.com>", "Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -128,7 +128,7 @@ else
     const _BIGINT_10s = BigInt[] # buffer for "remainders" in _divpow10!, accessed via `access_threaded`
     const _BIGINT_Rs = BigInt[]  # buffer for "remainders" in _divpow10!, accessed via `access_threaded`
 
-    _get_bigint10s() = access_threaded(() -> (@static VERSION > v"1.5" ? BigInt(; nbits=256) : BigInt()), _BIGIN_10s)
+    _get_bigint10s() = access_threaded(() -> (@static VERSION > v"1.5" ? BigInt(; nbits=256) : BigInt()), _BIGINT_10s)
     _get_bigintRs() = access_threaded(() -> (@static VERSION > v"1.5" ? BigInt(; nbits=256) : BigInt()), _BIGINT_Rs)
 
     function access_threaded(f, v::Vector)

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -116,12 +116,41 @@ const FD = FixedDecimal
 
 include("parse.jl")
 
-function __init__()
-    nt = isdefined(Base.Threads, :maxthreadid) ? Threads.maxthreadid() : Threads.nthreads()
-    # Buffers used in parsing when dealing with BigInts, see _divpow10! in parse.jl
-    resize!(empty!(_BIGINT_10s), nt)
-    resize!(empty!(_BIGINT_Rs), nt)
-    return
+const _BIGINT1 = BigInt(1)
+const _BIGINT2 = BigInt(2)
+const _BIGINT10 = BigInt(10)
+# Adapted from Parsers.jl, see https://github.com/JuliaData/Parsers.jl/pull/195
+@static if isdefined(Base, :OncePerTask)
+    const _get_bigint10s = OncePerTask{BigInt}(() -> BigInt(; nbits=256))
+    const _get_bigintRs = OncePerTask{BigInt}(() -> BigInt(; nbits=256))
+else
+    # N.B This code is not thread safe in the presence of thread migration
+    const _BIGINT_10s = BigInt[] # buffer for "remainders" in _divpow10!, accessed via `access_threaded`
+    const _BIGINT_Rs = BigInt[]  # buffer for "remainders" in _divpow10!, accessed via `access_threaded`
+
+    _get_bigint10s() = access_threaded(() -> (@static VERSION > v"1.5" ? BigInt(; nbits=256) : BigInt()), _BIGIN_10s)
+    _get_bigintRs() = access_threaded(() -> (@static VERSION > v"1.5" ? BigInt(; nbits=256) : BigInt()), _BIGINT_Rs)
+
+    function access_threaded(f, v::Vector)
+        tid = Threads.threadid()
+        0 < tid <= length(v) || _length_assert()
+        if @inbounds isassigned(v, tid)
+            @inbounds x = v[tid]
+        else
+            x = f()
+            @inbounds v[tid] = x
+        end
+        return x
+    end
+    @noinline _length_assert() = @assert false "0 < tid <= v"
+
+    function __init__()
+        nt = isdefined(Base.Threads, :maxthreadid) ? Threads.maxthreadid() : Threads.nthreads()
+        # Buffers used in parsing when dealing with BigInts, see _divpow10! in parse.jl
+        resize!(empty!(_BIGINT_10s), nt)
+        resize!(empty!(_BIGINT_Rs), nt)
+        return
+    end
 end
 
 # Custom widemul implementation to avoid the cost of widening to BigInt.


### PR DESCRIPTION
Mostly copy-pasted the identical fix from https://github.com/JuliaData/Parsers.jl/pull/195
Fixes: #120
Bumps version to `0.6.4`
